### PR TITLE
Ease of use for test rotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ AutoIndent.exe
 QuickIndent.exe
 .idea
 misc.xml
+Rotations/Test

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ config.ini
 AutoIndent.exe
 QuickIndent.exe
 .idea
+misc.xml

--- a/Rotations/Paladin/Protection/protectionPrettyBoy.lua
+++ b/Rotations/Paladin/Protection/protectionPrettyBoy.lua
@@ -569,7 +569,7 @@ actions+=/hammer_of_the_righteous]]
                         if cast.avengersShield() then return end
                     end
             -- Consecration actions+=/consecration
-                    if isChecked("Consecration") and not isMoving("player") and (not buff.consecration.exists()) and getDistance(units.dyn5) < 5 then
+                    if isChecked("Consecration") and not isMoving("player") and getDistance(units.dyn5) < 5 then
                         if cast.consecration() then return end
                     end
             -- Judgment actions+=/judgment

--- a/misc.xml
+++ b/misc.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+
+</Ui>


### PR DESCRIPTION
Add your rotation to the misc.xml file and put them in the Rotations/Test folder and git will not track it. Making sync easier.
