### PR TITLE
Massive changes to single target rotation and AOE rotation

### DIFF
--- a/Rotations/Mage/Frost/FrostLyLoLoq.lua
+++ b/Rotations/Mage/Frost/FrostLyLoLoq.lua
@@ -1,4 +1,4 @@
-local rotationName = "LyLoLoq" -- Change to name of profile listed in options drop down
+local rotationName = "Lyloloq" -- Change to name of profile listed in options drop down
 --------------
 --- COLORS ---
 --------------
@@ -621,14 +621,18 @@ local function runRotation()
                     if cast.iceNova() then return true end
                 end
             end
-            --actions.aoe+=/ice_lance,if=variable.fof_react>0
-            if fof_react > 0 then
-                if cast.iceLance(target) then return true end
+            
+            --water_jet,if=prev_gcd.1.frostbolt&buff.fingers_of_frost.stack<(2+artifact.icy_hand.enabled)&buff.brain_freeze.react=0
+            if lastCast == spell.frostbolt and isCastingSpell(spell.frostbolt) and buff.fingersOfFrost.stack() < (2 + iceHand) and not buff.brainFreeze.exists() then
+                CastSpellByName(GetSpellInfo(spell.waterJet))
+                lastCast = spell.waterJet
             end
+            
             --actions.aoe+=/flurry,if=prev_gcd.1.ebonbolt|prev_gcd.1.frostbolt&buff.brain_freeze.react
             if buff.brainFreeze.exists() and fof_react == 0 then
                 if cast.flurry(target) then return true end
             end
+            
             --actions.aoe+=/frost_bomb,if=debuff.frost_bomb.remains<action.ice_lance.travel_time&variable.fof_react>0
             if talent.frostBomb then
                 if lastCast ~= spell.frostBomb then
@@ -637,6 +641,12 @@ local function runRotation()
                     end
                 end
             end
+            
+            --actions.aoe+=/ice_lance,if=variable.fof_react>0
+            if fof_react > 0 then
+                if cast.iceLance(target) then return true end
+            end
+            
             --actions.aoe+=/ebonbolt,if=buff.brain_freeze.react=0
             if (getOptionValue("Artifact") == 1 or (getOptionValue("Artifact") == 2 and useCDs())) then
                 if not buff.brainFreeze.exists() then
@@ -651,6 +661,8 @@ local function runRotation()
             end
             --actions.aoe+=/frostbolt
             if cast.frostbolt(target) then return true end
+            
+            if cast.iceLance(target) then return true end
             return false
         end
 
@@ -750,13 +762,13 @@ local function runRotation()
             
             -- blizzard,if=active_enemies>2|active_enemies>1&!(talent.glacial_spike.enabled&talent.splitting_ice.enabled)|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
             if cd.blizzard == 0 then
+                if (#enemies.yards8t > 2) or (#enemies.yards8t > 1 and talent.glacialSpike and talent.splittingIce) then
+                    if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+                end
                 if isChecked(colorLegendary.."Zann'esu Journey") then
                     if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
                         if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
                     end
-                end
-                if (#enemies.yards8t > 2 or #enemies.yards8t > 1) and (talent.glacialSpike and talent.splittingIce) then
-                    if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
                 end
             end
             
@@ -776,7 +788,7 @@ local function runRotation()
             end
             
             if cast.frostbolt(target) then return true end
-            
+            if cast.iceLance(target) then return true end
             return false
             
         end

--- a/Rotations/Mage/Frost/FrostLyLoLoq.lua
+++ b/Rotations/Mage/Frost/FrostLyLoLoq.lua
@@ -1,4 +1,4 @@
-local rotationName = "Lyloloq" -- Change to name of profile listed in options drop down
+local rotationName = "LyLoLoq" -- Change to name of profile listed in options drop down
 --------------
 --- COLORS ---
 --------------

--- a/Rotations/Mage/Frost/FrostLyLoLoq.lua
+++ b/Rotations/Mage/Frost/FrostLyLoLoq.lua
@@ -154,8 +154,10 @@ local function runRotation()
     local ttd                                           = getTTD
     local enemies                                       = enemies or {}
     local units                                         = units or {}
+    local t20_2pc                                       = TierScan("T20") >= 2
 
     enemies.yards40 = br.player.enemies(40)
+    enemies.yards8t = br.player.enemies(8,br.player.units(8,true))
 
     if isChecked("Dynamic Targetting") then
         units.dyn40 = br.player.units(40)
@@ -172,6 +174,7 @@ local function runRotation()
     if artifact.icyHand then iceHand= 1 else iceHand = 0 end
     if iv_start == nil then iv_start = 0 end
     if fof_react == nil then fof_react = 0 end
+    if t20_2pc then t20pc2 = 1 else t20pc2 = 0 end
     if time_until_fof == nil then time_until_fof = 0 end
     if not inCombat and not GetObjectExists(target) then
         POT   = false
@@ -540,11 +543,13 @@ local function runRotation()
                         end
                     end
                 end
+
                 --actions.cooldowns+=/variable,name=iv_start,value=time,if=cooldown.icy_veins.ready&buff.icy_veins.down
                 if cd.icyVeins == 0 and not buff.icyVeins.exists() then
                     if debug == true then Print("iv_start Changed: "..iv_start) end
                     iv_start = getCombatTime()
                 end
+                
                 --actions.cooldowns+=/icy_veins,if=buff.icy_veins.down
                 if useCDs() and isChecked(colorBlueMage.."Icy Veins") and cd.icyVeins == 0 then
                     if not buff.icyVeins.exists() then
@@ -590,6 +595,7 @@ local function runRotation()
                     if cast.frozenOrb() then return true end
                 end
             end
+            
             --actions.aoe+=/blizzard
             if  cd.blizzard == 0 then
                 if isChecked(colorLegendary.."Zann'esu Journey") then
@@ -649,16 +655,31 @@ local function runRotation()
         end
 
         local function actionList_SINGLE()
-            --actions.single+=/frostbolt,if=prev_off_gcd.water_jet
-            if lastCast == spell.waterJet and getCastTime(spell.frostbolt)+0.2 < getCastTimeRemain("pet") then
-                if cast.frostbolt(target) then return true end
-            end
+            
             --actions.single=ice_nova,if=debuff.winters_chill.up--why?
             if talent.iceNova then
                 if  cd.iceNova == 0 then
                     if cast.iceNova() then return true end
                 end
             end
+            --  frozen_orb,if=set_bonus.tier20_2pc
+            if cd.frozenOrb == 0 and t20pc2 then
+                if isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 then
+                    if cast.frozenOrb() then return true end
+                end
+            end
+            
+            --actions.single+=/frostbolt,if=prev_off_gcd.water_jet
+            if lastCast == spell.waterJet and getCastTime(spell.frostbolt)+0.2 < getCastTimeRemain("pet") then
+                if cast.frostbolt(target) then return true end
+            end
+            
+            --water_jet,if=prev_gcd.1.frostbolt&buff.fingers_of_frost.stack<(2+artifact.icy_hand.enabled)&buff.brain_freeze.react=0
+            if lastCast == spell.frostbolt and isCastingSpell(spell.frostbolt) and buff.fingersOfFrost.stack() < (2 + iceHand) and not buff.brainFreeze.exists() then
+                CastSpellByName(GetSpellInfo(spell.waterJet))
+                lastCast = spell.waterJet
+            end
+            
             --actions.single+=/ray_of_frost,if=buff.icy_veins.up|(cooldown.icy_veins.remains>action.ray_of_frost.cooldown&buff.rune_of_power.down)
             if talent.rayOfFrost then
                 if  cd.rayOfFrost == 0 then
@@ -669,14 +690,20 @@ local function runRotation()
                     end
                 end
             end
-            --actions.single+=/ice_lance,if=variable.fof_react>0&cooldown.icy_veins.remains>10|variable.fof_react>2
-            if (fof_react > 0 and cd.icyVeins > 10) or (not useCDs() and fof_react > 0) or fof_react > 2 then
-                if cast.iceLance(target) then return true end
-            end
-            --actions.single+=/flurry,if=prev_gcd.1.ebonbolt|prev_gcd.1.frostbolt&buff.brain_freeze.react
-            if buff.brainFreeze.exists() and fof_react == 0 then
+            
+            -- flurry,if= prev_gcd.1.ebonbolt | buff.brain_freeze.react&(!talent.glacial_spike.enabled&prev_gcd.1.frostbolt | talent.glacial_spike.enabled&(prev_gcd.1.glacial_spike | prev_gcd.1.frostbolt&(buff.icicles.stack<=3 | cooldown.frozen_orb.remains<=10&set_bonus.tier20_2pc)))
+            if (lastCast == spell.ebonbolt) or (buff.brainFreeze.exists() and not talent.glacialSpike and lastCast == spell.frostbolt) or (talent.glacialSpike and lastCast == glacialSpike) or (lastCast == spell.frostbolt and buff.icicles.stack() <= 3 ) or (cd.frozenOrb <= 10 and t20pc2) then
                 if cast.flurry(target) then return true end
             end
+    
+            --blizzard,if=cast_time=0&active_enemies>1&variable.fof_react<3
+            if cd.blizzard == 0 then
+                if getCastTime(spell.blizzard) == 0 and fof_react < 3  then
+                    if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+                end
+            end
+            
+
             --actions.single+=/frost_bomb,if=debuff.frost_bomb.remains<action.ice_lance.travel_time&variable.fof_react>0
             if talent.frostBomb then
                 if lastCast ~= spell.frostBomb then
@@ -685,24 +712,34 @@ local function runRotation()
                     end
                 end
             end
+            
+            --actions.single+=/ice_lance,if=variable.fof_react>0&cooldown.icy_veins.remains>10|variable.fof_react>2
+            if (fof_react > 0 and cd.icyVeins > 10) or (not useCDs() and fof_react > 0) or fof_react > 2 then
+                if cast.iceLance(target) then return true end
+            end
+            
+            --actions.single+=/ebonbolt,if=buff.brain_freeze.react=0
+            if (getOptionValue("Artifact") == 1 or (getOptionValue("Artifact") == 2 and useCDs())) then
+                if not buff.brainFreeze.exists() then
+                    if cast.ebonbolt(target) then return true end
+                end
+            end
+            
             --actions.single+=/frozen_orb
             if cd.frozenOrb == 0 then
-                if isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 and buff.fingersOfFrost.stack() < 2 then
+                if isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 then
                     if cast.frozenOrb() then return true end
                 end
             end
-            --actions.single+=/blizzard,if=cast_time=0&active_enemies>1&variable.fof_react<3
-            if cd.blizzard == 0 then
-                if isChecked(colorLegendary.."Zann'esu Journey") then
-                    if buff.zannesuJourney.stack() == 5 then
-                        if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
-                    end
-                end
-                if getCastTime(spell.blizzard) == 0 and fof_react < 3 and (lastCast == spell.frozenOrb or cd.frozenOrb > 5) then
-                    if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+            
+            --actions.single=ice_nova,if=debuff.winters_chill.up--why?
+            if talent.iceNova then
+                if  cd.iceNova == 0 then
+                    if cast.iceNova() then return true end
                 end
             end
-            --actions.single+=/comet_storm
+            
+            --  comet_storm
             if talent.cometStorm then
                 if cd.cometStorm == 0 then
                     if isChecked(colorBlueMage.."Comet Storm") and ( IsStandingTime(2,target) or GetUnitSpeed(target) <= 3) then
@@ -710,21 +747,38 @@ local function runRotation()
                     end
                 end
             end
-            --actions.single+=/ebonbolt,if=buff.brain_freeze.react=0
-            if (getOptionValue("Artifact") == 1 or (getOptionValue("Artifact") == 2 and useCDs())) then
-                if not buff.brainFreeze.exists() then
-                    if cast.ebonbolt(target) then return true end
+            
+            -- blizzard,if=active_enemies>2|active_enemies>1&!(talent.glacial_spike.enabled&talent.splitting_ice.enabled)|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
+            if cd.blizzard == 0 then
+                if isChecked(colorLegendary.."Zann'esu Journey") then
+                    if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
+                        if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+                    end
+                end
+                if (#enemies.yards8t > 2 or #enemies.yards8t > 1) and (talent.glacialSpike and talent.splittingIce) then
+                    if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
                 end
             end
-            --actions.single+=/glacial_spike
+            
+            --frostbolt,if=buff.frozen_mass.remains>execute_time+action.glacial_spike.execute_time+action.glacial_spike.travel_time&buff.brain_freeze.react=0&talent.glacial_spike.enabled
+            if (buff.frozenMass.remain() > ( getCastTime(spell.frostbolt) + getCastTime(spell.glacialSpike) + 1 ) and not buff.brainFreeze.exists() and talent.glacialSpike) then
+                if cast.frostbolt(target) then return true end
+            end
+            
+            --  glacial_spike,if=cooldown.frozen_orb.remains>10|!set_bonus.tier20_2pc
+            
             if talent.glacialSpike then
-                if buff.icicles.stack() == 5 then
-                    if cast.glacialSpike(target) then return true end
+                if cd.frozenOrb > 10 or not t20pc2 then
+                    if buff.icicles.stack() == 5 then 
+                        if cast.glacialSpike(target) then return true end
+                    end
                 end
             end
-            --actions.single+=/frostbolt
+            
             if cast.frostbolt(target) then return true end
+            
             return false
+            
         end
 
         local function actionList_COMBAT()


### PR DESCRIPTION
Changes to single target rotation for 7.2.5 update

With T20 2pc, Frozen Orb should be used as soon as it comes off CD.

Freezing Rain Blizzard. While the normal Blizzard action is usually enough, right after Frozen Orb the actor will be getting a lot of FoFs, which might delay Blizzard to the point where we miss out on Freezing Rain. Therefore, if we are not at a risk of overcapping on FoF, use Blizzard before using Ice Lance.

Winter's Chill from Flurry can apply to the spell cast right before (provided the travel time is long enough). This can be exploited to a great effect with Ebonbolt, Glacial Spike (which deal a lot of damage by themselves) and Frostbolt (as a guaranteed way to proc Frozen Veins and Chain Reaction). When using Glacial Spike, it is worth saving a Brain Freeze proc when Glacial Spike is right around the corner (i.e. with 4 or more Icicles). However, when the actor also has T20 2pc, Glacial Spike is delayed to fit into Frozen Mass, so we do not want to sit on a Brain Freeze proc for too long in that case.

Frost Bolt While Frozen Mass is active, we want to generate as many buffed Icicles as possible. However, we do not want to do this at the expense of the final Glacial Spike, which should be also used while Frozen Mass is active.

Glacial Spike is generally used as it is available, unless we have T20 2pc. In that case, Glacial Spike is delayed when Frozen Mass is happening soon (in less than 10 s).

Against low number of targets, Blizzard is used as a filler. Use it only against 2 or more targets, 3 or more when using Glacial Spike and Splitting Ice. Zann'esu buffed Blizzard is used only at 5 stacks.