### PR TITLE
Frost Mage: QOL Fixes

### DIFF
--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -638,14 +638,15 @@ local function runRotation()
             end
             
             --actions.aoe+=/blizzard
-			if isChecked(colorLegendary.."Zann'esu Journey") then
-				if buff.zannesuJourney.stack() == 5 then
-					if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
-				end
-			elseif lastCast == spell.frozenOrb or cd.frozenOrb > 5 then
-				if cast.blizzard("best", nil, getValue("AOE targets"), blizzardRadius) then return true end
-            end
-            
+			if cd.blizzard == 0 then
+				if isChecked(colorLegendary.."Zann'esu Journey") then
+					if buff.zannesuJourney.stack() == 5 then
+						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+					end
+				elseif cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+			end
+			
+			
             --actions.aoe+=/comet_storm
             if talent.cometStorm then
                 if cd.cometStorm == 0 then
@@ -951,6 +952,7 @@ local function runRotation()
                 if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
             end
         end
+		
         --cone of cold
         if cd.coneOfCold == 0 then
             if isChecked(colorBlueMage.."Cone of Cold") then

--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -947,8 +947,7 @@ local function runRotation()
                 if buff.zannesuJourney.stack() == 5 then
                     if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
                 end
-            end
-            if getCastTime(spell.blizzard) == 0 and fof_react < 3 and (lastCast == spell.frozenOrb or cd.frozenOrb > 5) then
+            elseif getCastTime(spell.blizzard) == 0 and fof_react < 3 and (lastCast == spell.frozenOrb or cd.frozenOrb > 5) then
                 if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
             end
         end

--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -630,6 +630,7 @@ local function runRotation()
             if lastCast == spell.waterJet and getCastTime(spell.frostbolt)+0.2 < getCastTimeRemain("pet") then
                 if cast.frostbolt(target) then return true end
             end
+			
             --actions.aoe+=/frozen_orb
             if cd.frozenOrb == 0 then
                 if isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 and buff.fingersOfFrost.stack() < 2 then
@@ -642,7 +643,7 @@ local function runRotation()
 				if isChecked(colorLegendary.."Zann'esu Journey") then
 					if buff.zannesuJourney.stack() == 5 then
 						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
-					end
+					elseif cast.blizzard("best", nil, 1, blizzardRadius) then return true end
 				elseif cast.blizzard("best", nil, 1, blizzardRadius) then return true end
 			end
 			


### PR DESCRIPTION
- variable iv_start now checks at the very beginning of the call actions list rather than in the middle of the cooldowns lists.
- Blizzard AOE properly fixed. Now uses blizzard 2nd in the AOE Priority list without conditions.
- Flurry was instantly being casted as soon as the user started moving. Now Flurry follows the same conditions as the single target APL.