### PR TITLE
Frost Mage: Moving Mode Changes

### DIFF
--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -830,7 +830,7 @@ local function runRotation()
             --Against low number of targets, Blizzard is used as a filler. Use it only against 2 or more targets, 3 or more when using Glacial Spike and Splitting Ice. 
             --Zann'esu buffed Blizzard is used only at 5 stacks.
 			
-			if  cd.blizzard == 0 then
+			if  cd.blizzard == 0 and getDistance(target) < 35 then
 				if hasEquiped(133970) then
 					if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
 						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
@@ -964,7 +964,7 @@ local function runRotation()
 		
         --blizzard
 		-- actions.single+=/blizzard,if=active_enemies>2|active_enemies>1&!(talent.glacial_spike.enabled&talent.splitting_ice.enabled)|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
-		if  cd.blizzard == 0 and getCastTime(spell.blizzard) == 0 and isMoving("player") then
+		if  cd.blizzard == 0 and getCastTime(spell.blizzard) == 0 and isMoving("player") and getDistance(target) < 35 then
 			if hasEquiped(133970) then
 				if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
 					if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end

--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -203,6 +203,7 @@ local function runRotation()
         WJ    = false
         RF    = false
         opener= false
+		
         seq = 0
         lastCast = 61304
     end
@@ -511,7 +512,7 @@ local function runRotation()
 
         return false
     end
-
+	
     local function actionList_PRECOMBAT()
         --actions.precombat=flask
         if isChecked("Flask / Crystal") then
@@ -587,7 +588,7 @@ local function runRotation()
                         useItem(13)
                     end
                 elseif getOptionValue("Trinket 1 Condition") == 2 then
-                    if isChecked("Trinket 1") and inCombat and getHP("target") <= getValue("Trinket 1") and canUse(13) and isBoss("target") then
+                    if isChecked("Trinket 1") and inCombat and getHP(target) <= getValue("Trinket 1") and canUse(13) and isBoss(target) then
                         useItem(13)
                     end
                 elseif getOptionValue("Trinket 1 Condition") == 3 then
@@ -601,7 +602,7 @@ local function runRotation()
                         useItem(14)
                     end
                 elseif getOptionValue("Trinket 2 Condition") == 2 then
-                    if isChecked("Trinket 2") and inCombat and getHP("target") <= getValue("Trinket 2") and canUse(14) and isBoss("target") then
+                    if isChecked("Trinket 2") and inCombat and getHP(target) <= getValue("Trinket 2") and canUse(14) and isBoss(target) then
                         useItem(14)
                     end
                 elseif getOptionValue("Trinket 2 Condition") == 3 then
@@ -633,7 +634,7 @@ local function runRotation()
 			
             --actions.aoe+=/frozen_orb
             if cd.frozenOrb == 0 then
-                if isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 and buff.fingersOfFrost.stack() < 2 then
+                if useCDs() and isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 and buff.fingersOfFrost.stack() < 2 then
                     if cast.frozenOrb() then return true end
                 end
             end
@@ -643,8 +644,8 @@ local function runRotation()
 				if isChecked(colorLegendary.."Zann'esu Journey") then
 					if buff.zannesuJourney.stack() == 5 then
 						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
-					elseif cast.blizzard("best", nil, 1, blizzardRadius) then return true end
-				elseif cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+					elseif cast.blizzard("best", nil, getValue("AOE targets"), blizzardRadius) then return true end
+				elseif cast.blizzard("best", nil, getValue("AOE targets"), blizzardRadius) then return true end
 			end
 			
 			
@@ -726,7 +727,7 @@ local function runRotation()
             
             --  With T20 2pc, Frozen Orb should be used as soon as it comes off CD.
             if cd.frozenOrb == 0 and t20pc2 then
-                if isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 then
+                if useCDs() and isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 then
                     if cast.frozenOrb() then return true end
                 end
             end
@@ -801,7 +802,7 @@ local function runRotation()
             
             --actions.single+=/frozen_orb
             if cd.frozenOrb == 0 then
-                if isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 then
+                if useCDs() and isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 then
                     if cast.frozenOrb() then return true end
                 end
             end
@@ -825,16 +826,13 @@ local function runRotation()
             --Blizzard,if=active_enemies>2|active_enemies>1&!(talent.glacial_spike.enabled&talent.splitting_ice.enabled)|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
             --Against low number of targets, Blizzard is used as a filler. Use it only against 2 or more targets, 3 or more when using Glacial Spike and Splitting Ice. 
             --Zann'esu buffed Blizzard is used only at 5 stacks.
-            if cd.blizzard == 0 then
-                if (#enemies.yards8t > 2) or (#enemies.yards8t > 1 and not (talent.glacialSpike and talent.splittingIce)) then
-                    if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
-
-                elseif isChecked(colorLegendary.."Zann'esu Journey") then
-                    if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
-                        if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
-                    end
-                end
-            end
+			if cd.blizzard == 0 and not isMoving("player") and (#enemies.yards8t > 2 or (#enemies.yards8t > 1 and not (talent.glacialSpike and talent.splittingIce)) or buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard)) then
+				if isChecked(colorLegendary.."Zann'esu Journey") and hasEquiped(133970) then 
+					if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+				else
+					if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+				end
+			end
             
             --frostbolt,if=buff.frozen_mass.remains>execute_time+action.glacial_spike.execute_time+action.glacial_spike.travel_time&buff.brain_freeze.react=0&talent.glacial_spike.enabled
             --While Frozen Mass is active, we want to generate as many buffed Icicles as possible. 
@@ -862,18 +860,13 @@ local function runRotation()
             
             if cast.frostbolt(target) then return true end
             
-            if cd.blizzard == 0 then
-                if getCastTime(spell.blizzard) == 0 then
-                    if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
-                end
-            end
-            
-            if cast.iceLance(target) then return true end
             return false
             
         end
 
         local function actionList_COMBAT()
+			
+		
 			if cd.icyVeins == 0 and not buff.icyVeins.exists() then
 				if debug == true then Print("iv_start Changed: "..iv_start) end
 					iv_start = getCombatTime()
@@ -919,59 +912,79 @@ local function runRotation()
     end
 
     local function MovingMode()
-        --flurry com buff
-        if lastCast == spell.ebonbolt or buff.brainFreeze.exists() and (not talent.glacialSpike and lastCast == spell.frostbolt or talent.glacialSpike and (lastCast == spell.glacialSpike or lastCast == spell.frostbolt and (buff.icicles.stack() <= 3 or cd.frozenOrb <= 10 and t202pc))) then
-			if cast.flurry(target) then return true end
-		end
 		
-		if cd.frozenOrb == 0 and t20pc2 then
-			if isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 then
+	-- Frozen Orb
+		-- If we are moving and we have the Tier 20 2 piece bonus we should always frozen orb first.
+		if isMoving("player") and cd.frozenOrb == 0 and t20pc2 then
+			if useCDs() and isChecked(colorBlueMage.."Frozen Orb") and getEnemiesInRect(15,55,false) > 0 then
 				if cast.frozenOrb() then return true end
 			end
+		end	
+	
+    -- Flurry
+        if isMoving("player") and lastCast == spell.ebonbolt or buff.brainFreeze.exists() and (not talent.glacialSpike and lastCast == spell.frostbolt or talent.glacialSpike and (lastCast == spell.glacialSpike or lastCast == spell.frostbolt and (buff.icicles.stack() <= 3 or cd.frozenOrb <= 10 and t202pc))) then
+			if cast.flurry(target) then return true end
 		end
-		
-        --fingers of frost
-        if buff.fingersOfFrost.exists() then
-            if cast.iceLance(target) then
-                return true
+	
+	-- Instant cast blizzard
+		-- While the normal Blizzard action is usually enough, right after Frozen Orb the actor will be getting a lot of FoFs, which might delay Blizzard to the point where we miss out on Freezing Rain. 
+		-- Therefore, if we are not at a risk of overcapping on FoF, use Blizzard before using Ice Lance.
+		if cd.blizzard == 0 and isMoving("player") then
+            if getCastTime(spell.blizzard) == 0 and fof_react < 3 and (lastCast == spell.frozenOrb or cd.frozenOrb > 5) then
+                if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
             end
         end
+		
+        --actions.single+=/ice_lance,if=variable.fof_react>0&cooldown.icy_veins.remains>10|variable.fof_react>2
+		if isMoving("player") and ((fof_react > 0 and cd.icyVeins > 10) or (not useCDs() and fof_react > 0) or fof_react > 2) then
+			if cast.iceLance(target) then return true end
+		end
+		
         --frozen orb
-        if useCDs() and isChecked(colorBlueMage.."Frozen Orb") and cd.frozenOrb == 0 and getEnemiesInRect(15,55,false) > 0 then
+        if useCDs() and isMoving("player") and useCDs() and isChecked(colorBlueMage.."Frozen Orb") and cd.frozenOrb == 0 and getEnemiesInRect(15,55,false) > 0 then
             if cast.frozenOrb() then
                 return true
             end
         end
 		
-        --blizzard
-        if cd.blizzard == 0 then
-            if isChecked(colorLegendary.."Zann'esu Journey") then
-                if buff.zannesuJourney.stack() == 5 then
-                    if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
-                end
-            elseif getCastTime(spell.blizzard) == 0 and fof_react < 3 and (lastCast == spell.frozenOrb or cd.frozenOrb > 5) then
-                if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
-            end
-        end
+		if talent.cometStorm and isMoving("player")then
+			if cd.cometStorm == 0 then
+				if isChecked(colorBlueMage.."Comet Storm") and ( IsStandingTime(2,target) or GetUnitSpeed(target) <= 3) then
+					if cast.cometStorm(target) then return true end
+				end
+			end
+		end
 		
-        --cone of cold
-        if cd.coneOfCold == 0 then
+        --blizzard
+		-- actions.single+=/blizzard,if=active_enemies>2|active_enemies>1&!(talent.glacial_spike.enabled&talent.splitting_ice.enabled)|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
+		if cd.blizzard == 0 and isMoving("player") and getCastTime(spell.blizzard) == 0 and (#enemies.yards8t > 2 or (#enemies.yards8t > 1 and not (talent.glacialSpike and talent.splittingIce)) or buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard)) then
+			if isChecked(colorLegendary.."Zann'esu Journey") and hasEquiped(133970) then 
+				if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+			else
+				if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+			end
+		end
+		
+
+        if cd.coneOfCold == 0 and isMoving("player") then
             if isChecked(colorBlueMage.."Cone of Cold") then
                 if getFacing("player",target,50) and getDistance(target) < 12 then
                     if cast.coneOfCold("player") then return true end
                 end
             end
         end
-        --ice nova
-        if talent.iceNova and cd.iceNova == 0 then
-            if cast.iceNova() then return true end
-        end
-        --frostNova
-        if #br.player.enemies(12) > 0 then
+		
+		if #br.player.enemies(12) > 0 and isMoving("player") then
             if cast.frostNova() then return true end
         end
-        --ice lance
-        if cast.iceLance(target) then return true end
+		
+		if talent.iceNova and cd.iceNova == 0 and isMoving("player") then
+            if cast.iceNova() then return true end
+        end
+		
+		
+        --ice lance if all else fails
+        if cast.iceLance(target) and isMoving("player") then return true end
     end
     -----------------
     --- Rotations ---

--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -779,7 +779,7 @@ local function runRotation()
             --Freezing Rain Blizzard. 
             --While the normal Blizzard action is usually enough, right after Frozen Orb the actor will be getting a lot of FoFs, which might delay Blizzard to the point where we miss out on Freezing Rain. 
             --Therefore, if we are not at a risk of overcapping on FoF, use Blizzard before using Ice Lance.
-            if cd.blizzard == 0 and getDistance(target) < 35 then
+            if cd.blizzard == 0 then
                 if getCastTime(spell.blizzard) == 0 and #enemies.yards8t > 1 and fof_react < 3  then
                     cast.blizzard(target)
 					local X,Y,Z = ObjectPosition(target)
@@ -836,7 +836,7 @@ local function runRotation()
             --Against low number of targets, Blizzard is used as a filler. Use it only against 2 or more targets, 3 or more when using Glacial Spike and Splitting Ice. 
             --Zann'esu buffed Blizzard is used only at 5 stacks.
 			
-			if  cd.blizzard == 0 and getDistance(target) < 35 then
+			if  cd.blizzard == 0 then
 				if hasEquiped(133970) then
 					if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
 						cast.blizzard(target)
@@ -946,7 +946,7 @@ local function runRotation()
 	-- Instant cast blizzard
 		-- While the normal Blizzard action is usually enough, right after Frozen Orb the actor will be getting a lot of FoFs, which might delay Blizzard to the point where we miss out on Freezing Rain. 
 		-- Therefore, if we are not at a risk of overcapping on FoF, use Blizzard before using Ice Lance.
-		if cd.blizzard == 0 and isMoving("player") and getDistance(target) < 35 then
+		if cd.blizzard == 0 and isMoving("player") then
             if getCastTime(spell.blizzard) == 0 and fof_react < 3 and (lastCast == spell.frozenOrb or cd.frozenOrb > 5) then
                 cast.blizzard(target)
 				local X,Y,Z = ObjectPosition(target)
@@ -976,7 +976,7 @@ local function runRotation()
 		
         --blizzard
 		-- actions.single+=/blizzard,if=active_enemies>2|active_enemies>1&!(talent.glacial_spike.enabled&talent.splitting_ice.enabled)|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
-		if  cd.blizzard == 0 and getCastTime(spell.blizzard) == 0 and isMoving("player") and getDistance(target) < 35 then
+		if  cd.blizzard == 0 and getCastTime(spell.blizzard) == 0 and isMoving("player") then
 			if hasEquiped(133970) then
 				if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
 					cast.blizzard(target)

--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -211,7 +211,7 @@ local function runRotation()
     --------------------
     --- Action Lists ---
     --------------------
-    
+
 
     local function actionList_INTERRUPT()
         if useInterrupts() then
@@ -643,11 +643,15 @@ local function runRotation()
 			if  cd.blizzard == 0 then
 				if hasEquiped(133970) then
 					if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
-						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+						cast.blizzard(target)
+						local X,Y,Z = ObjectPosition(target)
+						ClickPosition(X,Y,Z)
 					end
 				end
 				if #enemies.yards8t > 2 or (#enemies.yards8t > 1 and not(talent.glacialSpike and talent.splittingIce)) then
-					if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+					cast.blizzard(target)
+					local X,Y,Z = ObjectPosition(target)
+					ClickPosition(X,Y,Z)
 				end
 			end
 			
@@ -777,7 +781,9 @@ local function runRotation()
             --Therefore, if we are not at a risk of overcapping on FoF, use Blizzard before using Ice Lance.
             if cd.blizzard == 0 and getDistance(target) < 35 then
                 if getCastTime(spell.blizzard) == 0 and #enemies.yards8t > 1 and fof_react < 3  then
-                    if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+                    cast.blizzard(target)
+					local X,Y,Z = ObjectPosition(target)
+					ClickPosition(X,Y,Z)
                 end
             end
             
@@ -833,11 +839,15 @@ local function runRotation()
 			if  cd.blizzard == 0 and getDistance(target) < 35 then
 				if hasEquiped(133970) then
 					if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
-						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+						cast.blizzard(target)
+						local X,Y,Z = ObjectPosition(target)
+						ClickPosition(X,Y,Z)
 					end
 				end
 				if #enemies.yards8t > 2 or (#enemies.yards8t > 1 and not(talent.glacialSpike and talent.splittingIce)) then
-					if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+					cast.blizzard(target)
+					local X,Y,Z = ObjectPosition(target)
+					ClickPosition(X,Y,Z)
 				end
 			end
 			
@@ -938,7 +948,9 @@ local function runRotation()
 		-- Therefore, if we are not at a risk of overcapping on FoF, use Blizzard before using Ice Lance.
 		if cd.blizzard == 0 and isMoving("player") and getDistance(target) < 35 then
             if getCastTime(spell.blizzard) == 0 and fof_react < 3 and (lastCast == spell.frozenOrb or cd.frozenOrb > 5) then
-                if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+                cast.blizzard(target)
+				local X,Y,Z = ObjectPosition(target)
+				ClickPosition(X,Y,Z)
             end
         end
 		
@@ -967,11 +979,15 @@ local function runRotation()
 		if  cd.blizzard == 0 and getCastTime(spell.blizzard) == 0 and isMoving("player") and getDistance(target) < 35 then
 			if hasEquiped(133970) then
 				if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
-					if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+					cast.blizzard(target)
+					local X,Y,Z = ObjectPosition(target)
+					ClickPosition(X,Y,Z)
 				end
 			end
 			if #enemies.yards8t > 2 or (#enemies.yards8t and not(talent.glacialSpike and talent.splittingIce)) then
-				if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+				cast.blizzard(target)
+				local X,Y,Z = ObjectPosition(target)
+				ClickPosition(X,Y,Z)
 			end
 		end
 		

--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -647,7 +647,7 @@ local function runRotation()
 					end
 				end
 				if #enemies.yards8t > 2 or (#enemies.yards8t and not(talent.glacialSpike and talent.splittingIce)) then
-					if cast.blizzard("best", nil, getValue("AOE targets"), blizzardRadius) then return true end
+					if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
 				end
 			end
 			

--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -646,7 +646,7 @@ local function runRotation()
 						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
 					end
 				end
-				if #enemies.yards8t > 2 or (#enemies.yards8t and not(talent.glacialSpike and talent.splittingIce)) then
+				if #enemies.yards8t > 2 or (#enemies.yards8t > 1 and not(talent.glacialSpike and talent.splittingIce)) then
 					if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
 				end
 			end
@@ -836,7 +836,7 @@ local function runRotation()
 						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
 					end
 				end
-				if #enemies.yards8t > 2 or (#enemies.yards8t and not(talent.glacialSpike and talent.splittingIce)) then
+				if #enemies.yards8t > 2 or (#enemies.yards8t > 1 and not(talent.glacialSpike and talent.splittingIce)) then
 					if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
 				end
 			end

--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -111,13 +111,7 @@ local function createOptions()
         br.ui:createSpinner(section,  "Interrupt at",  0,  0,  100,  1,  colorWhite.."Cast Percentage to use at.")
 
         br.ui:checkSectionState(section)
-        ----------------------
-        --- LEGENDARY OPTIONS ---
-        ----------------------
-        section = br.ui:createSection(br.ui.window.profile, colorGold.."Legendary")
-        --br.ui:createSpinner(section, colorLegendary.."Zann'esu Journey", 1, 1, 100, 1, colorWhite.."Check to enable usage of Zann'esu Journey, and set the number of units to Blizzard to be cast on.")
-        --br.ui:createCheckbox(section, colorLegendary.."Norgannon's Foresight")
-        br.ui:checkSectionState(section)
+
     end
     optionTable = {{
         [1] = "Rotation Options",
@@ -643,15 +637,11 @@ local function runRotation()
 			if  cd.blizzard == 0 then
 				if hasEquiped(133970) then
 					if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
-						cast.blizzard(target)
-						local X,Y,Z = ObjectPosition(target)
-						ClickPosition(X,Y,Z)
+						if castGroundAtBestLocation(spell.blizzard,blizzardRadius,1,35,1) then return true end
 					end
 				end
 				if #enemies.yards8t > 2 or (#enemies.yards8t > 1 and not(talent.glacialSpike and talent.splittingIce)) then
-					cast.blizzard(target)
-					local X,Y,Z = ObjectPosition(target)
-					ClickPosition(X,Y,Z)
+					if castGroundAtBestLocation(spell.blizzard,blizzardRadius,1,35,1) then return true end
 				end
 			end
 			
@@ -781,9 +771,7 @@ local function runRotation()
             --Therefore, if we are not at a risk of overcapping on FoF, use Blizzard before using Ice Lance.
             if cd.blizzard == 0 then
                 if getCastTime(spell.blizzard) == 0 and #enemies.yards8t > 1 and fof_react < 3  then
-                    cast.blizzard(target)
-					local X,Y,Z = ObjectPosition(target)
-					ClickPosition(X,Y,Z)
+                    if castGroundAtBestLocation(spell.blizzard,blizzardRadius,1,35,1) then return true end
                 end
             end
             
@@ -839,15 +827,11 @@ local function runRotation()
 			if  cd.blizzard == 0 then
 				if hasEquiped(133970) then
 					if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
-						cast.blizzard(target)
-						local X,Y,Z = ObjectPosition(target)
-						ClickPosition(X,Y,Z)
+						if castGroundAtBestLocation(spell.blizzard,blizzardRadius,1,35,1) then return true end
 					end
 				end
 				if #enemies.yards8t > 2 or (#enemies.yards8t > 1 and not(talent.glacialSpike and talent.splittingIce)) then
-					cast.blizzard(target)
-					local X,Y,Z = ObjectPosition(target)
-					ClickPosition(X,Y,Z)
+					if castGroundAtBestLocation(spell.blizzard,blizzardRadius,1,35,1) then return true end
 				end
 			end
 			
@@ -882,8 +866,6 @@ local function runRotation()
         end
 
         local function actionList_COMBAT()
-			
-		
 			if cd.icyVeins == 0 and not buff.icyVeins.exists() then
 				if debug == true then Print("iv_start Changed: "..iv_start) end
 					iv_start = getCombatTime()
@@ -923,6 +905,7 @@ local function runRotation()
             if actionList_SINGLE() then return true end
             return false
         end
+		
 
         if actionList_COMBAT() then return true end
         return false
@@ -948,9 +931,7 @@ local function runRotation()
 		-- Therefore, if we are not at a risk of overcapping on FoF, use Blizzard before using Ice Lance.
 		if cd.blizzard == 0 and isMoving("player") then
             if getCastTime(spell.blizzard) == 0 and fof_react < 3 and (lastCast == spell.frozenOrb or cd.frozenOrb > 5) then
-                cast.blizzard(target)
-				local X,Y,Z = ObjectPosition(target)
-				ClickPosition(X,Y,Z)
+                if castGroundAtBestLocation(spell.blizzard,blizzardRadius,1,35,1) then return true end
             end
         end
 		
@@ -979,15 +960,11 @@ local function runRotation()
 		if  cd.blizzard == 0 and getCastTime(spell.blizzard) == 0 and isMoving("player") then
 			if hasEquiped(133970) then
 				if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
-					cast.blizzard(target)
-					local X,Y,Z = ObjectPosition(target)
-					ClickPosition(X,Y,Z)
+					if castGroundAtBestLocation(spell.blizzard,blizzardRadius,1,35,1) then return true end
 				end
 			end
 			if #enemies.yards8t > 2 or (#enemies.yards8t and not(talent.glacialSpike and talent.splittingIce)) then
-				cast.blizzard(target)
-				local X,Y,Z = ObjectPosition(target)
-				ClickPosition(X,Y,Z)
+				if castGroundAtBestLocation(spell.blizzard,blizzardRadius,1,35,1) then return true end
 			end
 		end
 		
@@ -1044,7 +1021,7 @@ local function runRotation()
                 else
                     if MovingMode() then return true end
                 end
-
+				
             end -- End In Combat Rotation
         end -- Pause
     end

--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -640,12 +640,12 @@ local function runRotation()
             end
             
             --actions.aoe+=/blizzard
-			if cd.blizzard == 0 then
-				if isChecked(colorLegendary.."Zann'esu Journey") then
-					if buff.zannesuJourney.stack() == 5 then
-						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
-					elseif cast.blizzard("best", nil, getValue("AOE targets"), blizzardRadius) then return true end
-				elseif cast.blizzard("best", nil, getValue("AOE targets"), blizzardRadius) then return true end
+			if #enemies.yards8t > 2 or ((isChecked(colorLegendary.."Zann'esu Journey") and (buff.zannesuJourney.stack() > 4 or buff.zannesuJourney.remain() < getCastTime(spell.blizzard) + 1)) and hasEquiped(133970)) then
+				if buff.zannesuJourney.stack() > 4 then
+					if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+				else
+					if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+				end
 			end
 			
 			
@@ -772,7 +772,7 @@ local function runRotation()
             --Freezing Rain Blizzard. 
             --While the normal Blizzard action is usually enough, right after Frozen Orb the actor will be getting a lot of FoFs, which might delay Blizzard to the point where we miss out on Freezing Rain. 
             --Therefore, if we are not at a risk of overcapping on FoF, use Blizzard before using Ice Lance.
-            if cd.blizzard == 0 then
+            if cd.blizzard == 0 and getDistance(target) < 35 then
                 if getCastTime(spell.blizzard) == 0 and #enemies.yards8t > 1 and fof_react < 3  then
                     if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
                 end
@@ -826,14 +826,15 @@ local function runRotation()
             --Blizzard,if=active_enemies>2|active_enemies>1&!(talent.glacial_spike.enabled&talent.splitting_ice.enabled)|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
             --Against low number of targets, Blizzard is used as a filler. Use it only against 2 or more targets, 3 or more when using Glacial Spike and Splitting Ice. 
             --Zann'esu buffed Blizzard is used only at 5 stacks.
-			if cd.blizzard == 0 and not isMoving("player") and (#enemies.yards8t > 2 or (#enemies.yards8t > 1 and not (talent.glacialSpike and talent.splittingIce)) or buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard)) then
-				if isChecked(colorLegendary.."Zann'esu Journey") and hasEquiped(133970) then 
+			
+			if #enemies.yards8t > 2 or (#enemies.yards8t > 1 and not (talent.glacialSpike and talent.splittingIce)) or ((isChecked(colorLegendary.."Zann'esu Journey") and (buff.zannesuJourney.stack() > 4 or buff.zannesuJourney.remain() < getCastTime(spell.blizzard) + 1)) and hasEquiped(133970)) then
+				if buff.zannesuJourney.stack() > 4 then
 					if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
 				else
 					if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
 				end
 			end
-            
+			
             --frostbolt,if=buff.frozen_mass.remains>execute_time+action.glacial_spike.execute_time+action.glacial_spike.travel_time&buff.brain_freeze.react=0&talent.glacial_spike.enabled
             --While Frozen Mass is active, we want to generate as many buffed Icicles as possible. 
             --However, we do not want to do this at the expense of the final Glacial Spike, which should be also used while Frozen Mass is active.
@@ -929,7 +930,7 @@ local function runRotation()
 	-- Instant cast blizzard
 		-- While the normal Blizzard action is usually enough, right after Frozen Orb the actor will be getting a lot of FoFs, which might delay Blizzard to the point where we miss out on Freezing Rain. 
 		-- Therefore, if we are not at a risk of overcapping on FoF, use Blizzard before using Ice Lance.
-		if cd.blizzard == 0 and isMoving("player") then
+		if cd.blizzard == 0 and isMoving("player") and getDistance(target) < 35 then
             if getCastTime(spell.blizzard) == 0 and fof_react < 3 and (lastCast == spell.frozenOrb or cd.frozenOrb > 5) then
                 if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
             end
@@ -957,8 +958,8 @@ local function runRotation()
 		
         --blizzard
 		-- actions.single+=/blizzard,if=active_enemies>2|active_enemies>1&!(talent.glacial_spike.enabled&talent.splitting_ice.enabled)|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
-		if cd.blizzard == 0 and isMoving("player") and getCastTime(spell.blizzard) == 0 and (#enemies.yards8t > 2 or (#enemies.yards8t > 1 and not (talent.glacialSpike and talent.splittingIce)) or buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard)) then
-			if isChecked(colorLegendary.."Zann'esu Journey") and hasEquiped(133970) then 
+		if #enemies.yards8t > 2 or (#enemies.yards8t > 1 and not (talent.glacialSpike and talent.splittingIce)) or ((isChecked(colorLegendary.."Zann'esu Journey") and (buff.zannesuJourney.stack() > 4 or buff.zannesuJourney.remain() < getCastTime(spell.blizzard) + 1)) and hasEquiped(133970)) then
+			if buff.zannesuJourney.stack() > 4 then
 				if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
 			else
 				if cast.blizzard("best", nil, 1, blizzardRadius) then return true end

--- a/Rotations/Mage/Frost/FrostLemon.lua
+++ b/Rotations/Mage/Frost/FrostLemon.lua
@@ -115,7 +115,7 @@ local function createOptions()
         --- LEGENDARY OPTIONS ---
         ----------------------
         section = br.ui:createSection(br.ui.window.profile, colorGold.."Legendary")
-        br.ui:createSpinner(section, colorLegendary.."Zann'esu Journey", 1, 1, 100, 1, colorWhite.."Check to enable usage of Zann'esu Journey, and set the number of units to Blizzard to be cast on.")
+        --br.ui:createSpinner(section, colorLegendary.."Zann'esu Journey", 1, 1, 100, 1, colorWhite.."Check to enable usage of Zann'esu Journey, and set the number of units to Blizzard to be cast on.")
         --br.ui:createCheckbox(section, colorLegendary.."Norgannon's Foresight")
         br.ui:checkSectionState(section)
     end
@@ -640,11 +640,14 @@ local function runRotation()
             end
             
             --actions.aoe+=/blizzard
-			if #enemies.yards8t > 2 or ((isChecked(colorLegendary.."Zann'esu Journey") and (buff.zannesuJourney.stack() > 4 or buff.zannesuJourney.remain() < getCastTime(spell.blizzard) + 1)) and hasEquiped(133970)) then
-				if buff.zannesuJourney.stack() > 4 then
-					if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
-				else
-					if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
+			if  cd.blizzard == 0 then
+				if hasEquiped(133970) then
+					if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
+						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+					end
+				end
+				if #enemies.yards8t > 2 or (#enemies.yards8t and not(talent.glacialSpike and talent.splittingIce)) then
+					if cast.blizzard("best", nil, getValue("AOE targets"), blizzardRadius) then return true end
 				end
 			end
 			
@@ -827,10 +830,13 @@ local function runRotation()
             --Against low number of targets, Blizzard is used as a filler. Use it only against 2 or more targets, 3 or more when using Glacial Spike and Splitting Ice. 
             --Zann'esu buffed Blizzard is used only at 5 stacks.
 			
-			if #enemies.yards8t > 2 or (#enemies.yards8t > 1 and not (talent.glacialSpike and talent.splittingIce)) or ((isChecked(colorLegendary.."Zann'esu Journey") and (buff.zannesuJourney.stack() > 4 or buff.zannesuJourney.remain() < getCastTime(spell.blizzard) + 1)) and hasEquiped(133970)) then
-				if buff.zannesuJourney.stack() > 4 then
-					if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
-				else
+			if  cd.blizzard == 0 then
+				if hasEquiped(133970) then
+					if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
+						if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+					end
+				end
+				if #enemies.yards8t > 2 or (#enemies.yards8t and not(talent.glacialSpike and talent.splittingIce)) then
 					if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
 				end
 			end
@@ -958,10 +964,13 @@ local function runRotation()
 		
         --blizzard
 		-- actions.single+=/blizzard,if=active_enemies>2|active_enemies>1&!(talent.glacial_spike.enabled&talent.splitting_ice.enabled)|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
-		if #enemies.yards8t > 2 or (#enemies.yards8t > 1 and not (talent.glacialSpike and talent.splittingIce)) or ((isChecked(colorLegendary.."Zann'esu Journey") and (buff.zannesuJourney.stack() > 4 or buff.zannesuJourney.remain() < getCastTime(spell.blizzard) + 1)) and hasEquiped(133970)) then
-			if buff.zannesuJourney.stack() > 4 then
-				if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
-			else
+		if  cd.blizzard == 0 and getCastTime(spell.blizzard) == 0 and isMoving("player") then
+			if hasEquiped(133970) then
+				if buff.zannesuJourney.stack() == 5 and buff.zannesuJourney.remain() > getCastTime(spell.blizzard) then
+					if cast.blizzard("best", nil, getValue(colorLegendary.."Zann'esu Journey"), blizzardRadius) then return true end
+				end
+			end
+			if #enemies.yards8t > 2 or (#enemies.yards8t and not(talent.glacialSpike and talent.splittingIce)) then
 				if cast.blizzard("best", nil, 1, blizzardRadius) then return true end
 			end
 		end


### PR DESCRIPTION
- Changes to 'While Moving' priority list to fix a dps loss in fights with a lot of movement.
- Frozen Orb now follows the Cooldown Toggle.
- Comet Storm has been added to the 'While Moving' priority list
- Blizzard will only attempt to cast if you're within 35 yards.
- Fixed weird interactions where blizzard would not be casted on enemies near walls therefore leaving the casting cursor on and pausing the rotation unless the user manually clicked a position. It will now cast blizzard on the targets true position rather than casting in the "best" position between multiple mobs.
- Removed Zann'esu Journey option, Rotation will now choose an optimal situation to cast Blizzard when players have this item equipped.