### PR TITLE
Make queue casting great again

### DIFF
--- a/Rotations/Warlock/Affliction/AfflictionFiskee.lua
+++ b/Rotations/Warlock/Affliction/AfflictionFiskee.lua
@@ -176,7 +176,7 @@ local function runRotation()
         local hasPet                                        = IsPetActive()
         local healPot                                       = getHealthPot()
         local heirloomNeck                                  = 122663 or 122664
-        local inCombat                                      = br.player.inCombat
+        local inCombat                                      = isInCombat("player")
         local inInstance                                    = br.player.instance=="party"
         local inRaid                                        = br.player.instance=="raid"
         local lastSpell                                     = lastSpellCast
@@ -390,6 +390,9 @@ local function runRotation()
 					end
 				end
 			end -- End Dummy Test
+      if isChecked("Shadowfury Hotkey") and shadowfuryKey and not GetCurrentKeyBoardFocus() then
+        if cast.shadowfury("best",false,1,8) then return end
+      end
       --Soulstone mouseover
       if isChecked("Auto Soulstone Mouseover") and inCombat and not moving and UnitIsPlayer("mouseover") and UnitIsDeadOrGhost("mouseover") and GetUnitIsFriend("mouseover","player") then
         if cast.soulstone("mouseover","dead") then return true end
@@ -781,7 +784,9 @@ local function runRotation()
         local function actionList_PreCombat()
         -- Summon Pet
             -- summon_pet,if=!talent.grimoire_of_supremacy.enabled&(!talent.grimoire_of_sacrifice.enabled|buff.demonic_power.down)
-            if isChecked("Pet Management") and not (IsFlying() or IsMounted()) and (not talent.grimoireOfSacrifice or not buff.demonicPower.exists()) and level >= 5 and br.timer:useTimer("summonPet", cast.time.summonVoidwalker() + 2) and not moving then
+            local petPadding = 2
+            if talent.grimoireOfSacrifice then petPadding = 5 end
+            if isChecked("Pet Management") and not (IsFlying() or IsMounted()) and (not talent.grimoireOfSacrifice or not buff.demonicPower.exists()) and level >= 5 and br.timer:useTimer("summonPet", cast.time.summonVoidwalker() + petPadding) and not moving then
               if (activePetId == 0 or activePetId ~= summonId) and (lastSpell ~= castSummonId or activePetId ~= summonId or activePetId == 0) then
                 if summonPet == 1 then
                   if isKnown(spell.summonFelImp) and (lastSpell ~= spell.summonFelImp or activePetId == 0) then
@@ -802,19 +807,16 @@ local function runRotation()
                 if summonPet == 5 then return end
               end
             end
+            -- grimoire_of_sacrifice,if=talent.grimoire_of_sacrifice.enabled
+            if talent.grimoireOfSacrifice and GetObjectExists("pet") and not UnitIsDeadOrGhost("pet") then
+                if cast.grimoireOfSacrifice() then return end
+            end
             if not inCombat and not (IsFlying() or IsMounted()) then
             -- Flask
                 -- flask,type=whispered_pact
             -- Food
                 -- food,type=azshari_salad
                 if (not isChecked("Opener") or opener == true) then
-                -- Augmentation
-                    -- augmentation,type=defiled
-                -- Grimoire of Sacrifice
-                    -- grimoire_of_sacrifice,if=talent.grimoire_of_sacrifice.enabled
-                    if talent.grimoireOfSacrifice and GetObjectExists("pet") and not UnitIsDeadOrGhost("pet") then
-                        if cast.grimoireOfSacrifice() then return end
-                    end
                     if useCDs() and isChecked("Pre-Pull Timer") then --and pullTimer <= getOptionValue("Pre-Pull Timer") then
                         if pullTimer <= getOptionValue("Pre-Pull Timer") - 0.5 then
                             if canUse(142117) and not buff.prolongedPower.exists() then
@@ -915,9 +917,6 @@ local function runRotation()
                 if isChecked("Pet Management") and not GetUnitIsUnit("pettarget","target") then
                     PetAttack()
                 end
-                if isChecked("Shadowfury Hotkey") and shadowfuryKey and not GetCurrentKeyBoardFocus() then
-                  if cast.shadowfury("best",false,1,8) then return end
-                end
                 --CDs
                 if useCDs() then
                   if actionList_Cooldowns() then return end
@@ -941,4 +940,5 @@ tinsert(br.rotations[id],{
     toggles = createToggles,
     options = createOptions,
     run = runRotation,
+    shadowFruy = false
 })

--- a/Rotations/Warlock/Destruction/DestructionFiskee.lua
+++ b/Rotations/Warlock/Destruction/DestructionFiskee.lua
@@ -164,7 +164,7 @@ local function runRotation()
         local healPot                                       = getHealthPot()
         local heirloomNeck                                  = 122663 or 122664
         local immolateCount                                 = br.player.debuff.immolate.count()
-        local inCombat                                      = br.player.inCombat
+        local inCombat                                      = isInCombat("player")
         local inInstance                                    = br.player.instance=="party"
         local inRaid                                        = br.player.instance=="raid"
         local lastSpell                                     = lastSpellCast
@@ -338,6 +338,9 @@ local function runRotation()
 					end
 				end
 			end -- End Dummy Test
+      if isChecked("Shadowfury Hotkey") and shadowfuryKey and not GetCurrentKeyBoardFocus() then
+        if cast.shadowfury("best",false,1,8) then return end
+      end
       if isChecked("Auto Soulstone Mouseover") and not moving and UnitIsPlayer("mouseover") and UnitIsDeadOrGhost("mouseover") and GetUnitIsFriend("mouseover","player") then
         if cast.soulstone("mouseover","dead") then return true end
       end
@@ -1000,8 +1003,10 @@ local function runRotation()
 
         local function actionList_PreCombat()
         -- Summon Pet
+            local petPadding = 2
+            if talent.grimoireOfSacrifice then petPadding = 5 end
             -- summon_pet,if=!talent.grimoire_of_supremacy.enabled&(!talent.grimoire_of_sacrifice.enabled|buff.demonic_power.down)
-            if isChecked("Pet Management") and not (IsFlying() or IsMounted()) and (not talent.grimoireOfSacrifice or not buff.demonicPower.exists()) and level >= 5 and br.timer:useTimer("summonPet", cast.time.summonVoidwalker() + 2) and not moving then
+            if isChecked("Pet Management") and not (IsFlying() or IsMounted()) and (not talent.grimoireOfSacrifice or not buff.demonicPower.exists()) and level >= 5 and br.timer:useTimer("summonPet", cast.time.summonVoidwalker() + petPadding) and not moving then
                 if (activePetId == 0 or activePetId ~= summonId) and (lastSpell ~= castSummonId or activePetId ~= summonId or activePetId == 0) then
                     if summonPet == 1 then
                       if isKnown(spell.summonFelImp) and (lastSpell ~= spell.summonFelImp or activePetId == 0) then
@@ -1022,17 +1027,16 @@ local function runRotation()
                     if summonPet == 5 then return end
                 end
             end
+            -- grimoire_of_sacrifice,if=talent.grimoire_of_sacrifice.enabled
+            if talent.grimoireOfSacrifice and GetObjectExists("pet") and not UnitIsDeadOrGhost("pet") then
+                if cast.grimoireOfSacrifice() then return end
+            end
             if not inCombat and not (IsFlying() or IsMounted()) then
             -- Flask
                 -- flask,type=whispered_pact
             -- Food
                 -- food,type=azshari_salad
                 if (not isChecked("Opener") or opener == true) then
-                -- Grimoire of Sacrifice
-                    -- grimoire_of_sacrifice,if=talent.grimoire_of_sacrifice.enabled
-                    if talent.grimoireOfSacrifice and GetObjectExists("pet") and not UnitIsDeadOrGhost("pet") then
-                        if cast.grimoireOfSacrifice() then return end
-                    end
                     if useCDs() and isChecked("Pre-Pull Timer") then --and pullTimer <= getOptionValue("Pre-Pull Timer") then
                         if pullTimer <= getOptionValue("Pre-Pull Timer") - 0.5 then
                             if canUse(142117) and not buff.prolongedPower.exists() then
@@ -1116,9 +1120,6 @@ local function runRotation()
         -- Pet Attack
                     if isChecked("Pet Management") and not GetUnitIsUnit("pettarget","target") then
                         PetAttack()
-                    end
-                    if isChecked("Shadowfury Hotkey") and shadowfuryKey and not GetCurrentKeyBoardFocus() then
-                      if cast.shadowfury("best",false,1,8) then return end
                     end
                     -- rotation
                     if actionList_Rotation() then return end

--- a/System/Core.lua
+++ b/System/Core.lua
@@ -123,16 +123,20 @@ function BadRotationsUpdate(self)
 			    -- Initialize Player
 				if br.player == nil or br.player.profile ~= br.selectedSpec or br.rotationChanged then
 					brLoaded = false
-			        br.player = br.loader:new(playerSpec,br.selectedSpec)
-			        setmetatable(br.player, {__index = br.loader})
-			        br.player:createOptions()
-			        br.player:createToggles()
-			        br.player:update()
+	        br.player = br.loader:new(playerSpec,br.selectedSpec)
+	        setmetatable(br.player, {__index = br.loader})
+	        br.player:createOptions()
+	        br.player:createToggles()
+	        br.player:update()
 					Print("Loaded Profile: "..br.player.rotation.name)
 					br.rotationChanged = false
-			    end
+		    end
+				-- Queue Casting
+				if (isChecked("Queue Casting") or (br.player ~= nil and br.player.queue ~= 0)) and not UnitChannelInfo("player") then
+					if castQueue() then return end
+				end
 			    -- Update Player
-			    if br.player ~= nil and not CanExitVehicle() then --br.debug.cpu.pulse.currentTime/10) then
+		    if br.player ~= nil and not CanExitVehicle() then --br.debug.cpu.pulse.currentTime/10) then
 					br.player:update()
 				end
 			-- Healing Engine
@@ -143,31 +147,23 @@ function BadRotationsUpdate(self)
 				autoLoot()
 			-- Close windows and swap br.selectedSpec on Spec Change
 				if select(2,GetSpecializationInfo(GetSpecialization())) ~= br.selectedSpec then
-			    	-- Closing the windows will save the position
-			        br.ui:closeWindow("all")
-
-			    	-- Update Selected Spec/Profile
-			        br.selectedSpec = select(2,GetSpecializationInfo(GetSpecialization()))
-			        br.activeSpecGroup = GetActiveSpecGroup()
-			        br:loadSettings()
-
-			        -- Recreate Config Window and commandHelp with new Spec
-			        if br.ui.window.config.parent == nil then br.ui:createConfigWindow() end
+	    	-- Closing the windows will save the position
+	        br.ui:closeWindow("all")
+	    	-- Update Selected Spec/Profile
+	        br.selectedSpec = select(2,GetSpecializationInfo(GetSpecialization()))
+	        br.activeSpecGroup = GetActiveSpecGroup()
+	        br:loadSettings()
+	        -- Recreate Config Window and commandHelp with new Spec
+	        if br.ui.window.config.parent == nil then br.ui:createConfigWindow() end
 					commandHelp = nil
 					commandHelp = ""
 					slashHelpList()
-			    end
+		    end
 
 			-- Display Distance on Main Icon
-		    	targetDistance = getDistance("target") or 0
-		    	displayDistance = math.ceil(targetDistance)
+	    	targetDistance = getDistance("target") or 0
+	    	displayDistance = math.ceil(targetDistance)
 				mainText:SetText(displayDistance)
-
-			-- Queue Casting
-				if (isChecked("Queue Casting") or (br.player ~= nil and br.player.queue ~= 0)) and not UnitChannelInfo("player") then
-					-- Catch for spells not registering on Combat log
-				    if castQueue() then return end
-				end
 
 			-- LoS Line Draw
 				if isChecked("Healer Line of Sight Indicator") then
@@ -176,7 +172,7 @@ function BadRotationsUpdate(self)
 
 		    -- get DBM Timer/Bars
 			    -- global -> br.DBM.Timer
-			    br.DBM:getBars()
+		    br.DBM:getBars()
 
 			-- Accept dungeon queues
 				br:AcceptQueues()
@@ -185,7 +181,7 @@ function BadRotationsUpdate(self)
 				ProfessionHelper()
 
 		    -- Rotation Log
-		    	br.ui:toggleDebugWindow()
+	    	br.ui:toggleDebugWindow()
 			end --End Update Check
 		end -- End Update In Progress Check
  	end -- End Main Button Active Check

--- a/System/Functions/Cast.lua
+++ b/System/Functions/Cast.lua
@@ -638,14 +638,10 @@ function castQueue()
 	-- Catch for spells not registering on Combat log
 	if br.player ~= nil then
 		if br.player.queue ~= nil and #br.player.queue > 0 and not IsAoEPending() then
-			local spellID = br.player.queue[1].id
-			--local spellName,_,texture = GetSpellInfo(spellID)
-			local thisUnit = br.player.queue[1].target
-			createCastFunction(thisUnit,nil,nil,nil,spellID)
-			if getOptionCheck("Start/Stop BadRotations") then
-				mainButton:SetNormalTexture(texture)
-				lastSpellCast = spellID
-				lastSpellTarget = UnitGUID(thisUnit)
+			for i=1, #br.player.queue do
+				local spellID = br.player.queue[i].id
+				local thisUnit = br.player.queue[i].target
+				if createCastFunction(thisUnit,nil,nil,nil,spellID) then return end
 			end
 		end
 	end

--- a/System/Functions/Cast.lua
+++ b/System/Functions/Cast.lua
@@ -291,24 +291,7 @@ function castSpell(Unit,SpellID,FacingCheck,MovementCheck,SpamAllowed,KnownSkip,
 	end
 	return false
 end
--- Cast Spell Queue
-function castQueue()
-	-- Catch for spells not registering on Combat log
-	if br.player ~= nil then
-		if br.player.queue ~= nil and #br.player.queue > 0 and not IsAoEPending() then
-			local spellID = br.player.queue[1].id
-			local spellName,_,texture = GetSpellInfo(spellID)
-			local thisUnit = br.player.queue[1].target
-			CastSpellByName(spellName,thisUnit)
-			if getOptionCheck("Start/Stop BadRotations") then
-				mainButton:SetNormalTexture(texture)
-				lastSpellCast = spellID
-				lastSpellTarget = UnitGUID(thisUnit)
-			end
-		end
-	end
-	return
-end
+
 --[[castSpellMacro(Unit,SpellID,FacingCheck,MovementCheck,SpamAllowed,KnownSkip)
 Parameter 	Value
 First 	 	UnitID 			Enter valid UnitID
@@ -648,4 +631,23 @@ function createCastFunction(thisUnit,debug,minUnits,effectRng,spellID,index)
     elseif debug == "debug" then
         return false
     end
+end
+
+-- Cast Spell Queue
+function castQueue()
+	-- Catch for spells not registering on Combat log
+	if br.player ~= nil then
+		if br.player.queue ~= nil and #br.player.queue > 0 and not IsAoEPending() then
+			local spellID = br.player.queue[1].id
+			--local spellName,_,texture = GetSpellInfo(spellID)
+			local thisUnit = br.player.queue[1].target
+			createCastFunction(thisUnit,nil,nil,nil,spellID)
+			if getOptionCheck("Start/Stop BadRotations") then
+				mainButton:SetNormalTexture(texture)
+				lastSpellCast = spellID
+				lastSpellTarget = UnitGUID(thisUnit)
+			end
+		end
+	end
+	return
 end


### PR DESCRIPTION
For some reason the queuecast function was placed after rotation in core. I think that if I queue up a cast, I want it to cast it next time.
Also it wasn't using the castSpell function, so would sometimes go in a loop, spamming the same action over and over.