### PR TITLE
System - Performance updates WROOOM!

### DIFF
--- a/System/Functions/Misc.lua
+++ b/System/Functions/Misc.lua
@@ -376,14 +376,14 @@ function isValidUnit(Unit)
 	local isCC = getOptionCheck("Don't break CCs") and isLongTimeCCed(Unit) or false
 	local mcCheck = (isChecked("Attack MC Targets") and (not GetUnitIsFriend(Unit,"player") or (UnitIsCharmed(Unit) and UnitCanAttack("player",Unit)))) or not GetUnitIsFriend(Unit,"player");
 	if playerTarget and br.units[UnitTarget("player")] == nil and not enemyListCheck("target") then return false end
-	if not pause(true) and Unit ~= nil and (br.units[Unit] ~= nil or Unit == "target" or validUnitBypassList[GetObjectID(Unit)]) and (not UnitIsTapDenied(Unit) or isDummy(Unit))
+	if not pause(true) and Unit ~= nil and (br.units[Unit] ~= nil or Unit == "target" or validUnitBypassList[GetObjectID(Unit)] ~= nil) and (not UnitIsTapDenied(Unit) or isDummy(Unit))
 		and ((reaction < 5 and not hostileOnly) or (hostileOnly and (reaction < 4 or playerTarget or targeting)) or isDummy(Unit)) and mcCheck and not isCC
 	then
 		local instance = IsInInstance()
 		local distance = getDistance(Unit,"target")
 		local inCombat = UnitAffectingCombat("player") or (GetObjectExists("pet") and UnitAffectingCombat("pet"))
 		local hasThreat = hasThreat(Unit) or targeting or isInProvingGround() or isBurnTarget(Unit) > 0
-		return hasThreat or (not instance and (playerTarget or distance < 8)) or (instance and playerTarget and ((getDistance(Unit,"player") < 20 or (UnitAffectingCombat(Unit) and getDistance(Unit,"player") < 40)) or #br.friend == 1)) or validUnitBypassList[GetObjectID(Unit)]
+		return hasThreat or (not instance and (playerTarget or distance < 8)) or (instance and playerTarget and ((getDistance(Unit,"player") < 20 or (UnitAffectingCombat(Unit) and getDistance(Unit,"player") < 40)) or #br.friend == 1)) or validUnitBypassList[GetObjectID(Unit)] ~= nil
 	end
 	return false
 end

--- a/System/UI/Windows/Config.lua
+++ b/System/UI/Windows/Config.lua
@@ -87,7 +87,6 @@ function br.ui:createConfigWindow()
         br.ui:createCheckbox(section, "Lockboxes", "Unlock Lockboxes.")
         br.ui:createCheckbox(section, "Quaking Helper", "Auto cancel channeling and block casts during mythic+ affix quaking")
         br.ui:createCheckbox(section, "Debug Timers", "Useless to users, for Devs.")
-        br.ui:createCheckbox(section, "Debug TTD", "Display time to die on units.")
         br.ui:checkSectionState(section)
     end
 

--- a/System/engines/EnemiesEngineFunctions.lua
+++ b/System/engines/EnemiesEngineFunctions.lua
@@ -43,6 +43,7 @@ function updateOM()
 	local omCounter = 0
 	local fmod = math.fmod
 	local loopSet = floor(GetFramerate()) or 0
+	local autoLoot = isChecked("Auto Loot")
 	-- if isChecked("Disable Object Manager") and (inCombat or not isChecked("Auto Loot")) then
 	-- 	if next(br.om) ~= nil then br.om = {} end
 	-- 	return
@@ -61,8 +62,8 @@ function updateOM()
 			if omCounter == 1 then cycleTime = debugprofilestop() end
 			-- define our unit
 			local thisUnit = GetObjectWithIndex(i)
-				if GetUnitIsVisible(thisUnit) and getDistance(thisUnit) < 50
-					and (GetUnitReaction(thisUnit,"player") < 5 or UnitCreator(thisUnit) == playerObject) and (not UnitIsDeadOrGhost(thisUnit) or CanLootUnit(UnitGUID(thisUnit)))
+				if ObjectIsUnit(thisUnit) and (GetUnitIsVisible(thisUnit) and getDistance(thisUnit) < 50
+					and (GetUnitReaction(thisUnit,"player") < 5 or UnitCreator(thisUnit) == playerObject) and (not UnitIsDeadOrGhost(thisUnit) or (autoLoot and CanLootUnit(UnitGUID(thisUnit)))))
 				then
 					br.debug.cpu.enemiesEngine.objects.targets = br.debug.cpu.enemiesEngine.objects.targets + 1
 					local enemyUnit = br.unitSetup:new(thisUnit)


### PR DESCRIPTION
Added check to make sure we don't waste ressources checking stuff that isn't a unit.
Only add lootable units to OM, if we have autoloot on.
Will now remove dead units from OM if they have no loot.
Will now only check isValidUnit in OM, if enemyListCheck is true, to save ressources.
Added Unit blacklist to OM (added the sharks)
Make isValidUnit not return nil, after whitelist was added
Removed TTD debug option, as it's perfect, and not needed anymore :)