### PR TITLE
Battle of Dazarlor, interrupts and notouch

### DIFF
--- a/System/Lists/NoTouchUnits.lua
+++ b/System/Lists/NoTouchUnits.lua
@@ -19,7 +19,12 @@ br.lists.noTouchUnits = {
     {unitID = 116691, buff = 235230}, -- Don't attack Belac while Fel Squall
     {unitID = 117264, buff = -241008}, -- Don't attack Maiden of Valor unless Buff is Present *** negative buff value denotes not present ***
     -- BfA
+    -- Uldir
     {unitID = 137119, buff = 271965}, -- Don't attack Taloc while Powered Down
     {unitID = 131227, buff = 260189}, -- Motherlode last boss flight
     {unitID = 136383, buff = 274230} -- Mythrax immunity
+    -- Battle of Dazar'alor
+    {unitID = 144683, buff = 284436}, -- Champion of the Light (A), Ra'wani Kanae, Seal of Reckoning
+    {unitID = 144683, buff = 284436}, -- Champion of the Light (H), Frida Ironbellows, Seal of Reckoning
+
 }

--- a/System/engines/EnemiesEngineCollections.lua
+++ b/System/engines/EnemiesEngineCollections.lua
@@ -204,6 +204,12 @@ interruptWhitelist = {
 	[272571] = true, -- choking-waters
 	[256957] = true, -- watertight-shell
 	-- Siege of Boralus end
+	-- Battle of Dazarlor start
+	[283628] = true, -- Heal of the forces of the crusade, champion of the light encounter
+	[282243] = true, -- Apetagonize, Grong encounter
+	[286379] = true, -- Pyroblast, Jade Masters encounter
+	-- Battle of Dazarlor end
+
 	-- Old Content start 
 	[191823] = true, -- Furious Blast
 	[191848] = true, -- Rampage


### PR DESCRIPTION
- don't attack Champion of Light during Seal of Reckoning
- interrupt the heals for Forces of Light
- interrupt Apetagonize from the adds of Grong
- interrupt Jade Masters mage pyroblast