### PR TITLE
"Auto stealth" means enter stealth, not enter-cancel spam.

### DIFF
--- a/Rotations/Rogue/Assassination/AssassinationFiskee.lua
+++ b/Rotations/Rogue/Assassination/AssassinationFiskee.lua
@@ -469,7 +469,7 @@ local function runRotation()
                 if cast.cripplingPoison("player") then return true end
             end
             -- actions.precombat+=/stealth
-            if isChecked("Auto Stealth") and IsUsableSpell(spell.stealth) and not cast.last.vanish() and not IsResting() and
+            if isChecked("Auto Stealth") and not stealth and IsUsableSpell(spell.stealth) and not cast.last.vanish() and not IsResting() and
             (botSpell ~= spell.stealth or (botSpellTime == nil or GetTime() - botSpellTime > 0.1)) then
                 if getOptionValue("Auto Stealth") == 1 then
                     if cast.stealth() then return end


### PR DESCRIPTION
Current version does endless stealth + unstealth because there is no "i'm already stealthed" check.
Let's fix it.