### PR TITLE
Feral - Fix for Regrowth

### DIFF
--- a/Rotations/Druid/Feral/FeralCuteOne.lua
+++ b/Rotations/Druid/Feral/FeralCuteOne.lua
@@ -1477,7 +1477,8 @@ local function runRotation()
                     end
                     -- Regrowth
                     -- regrowth,if=combo_points=5&buff.predatory_swiftness.up&talent.bloodtalons.enabled&buff.bloodtalons.down
-                    if cast.able.regrowth() and (comboPoints == 5 and buff.predatorySwiftness.exists()
+                    if (cast.able.regrowth() and (((comboPoints == 5 and buff.predatorySwiftness.exists())
+                        or (comboPoints == 4 and debuff.rake.remain(units.dyn5) < 5.1 and buff.predatorySwiftness.exists())))
                         and talent.bloodtalons and not buff.bloodtalons.exists())
                     then
                         local opValue = getOptionValue("Auto Heal")


### PR DESCRIPTION
Will now use Regrowth with 4 CP if rake is about to run out or Predatory Swiftness is about to run out.