### PR TITLE
New essence logic, added new potions

### DIFF
--- a/Rotations/Rogue/Assassination/AssassinationFiskee.lua
+++ b/Rotations/Rogue/Assassination/AssassinationFiskee.lua
@@ -94,7 +94,8 @@ local function createOptions()
         section = br.ui:createSection(br.ui.window.profile,  "Cooldowns")
             br.ui:createCheckbox(section, "Racial", "|cffFFFFFF Will use Racial")
             br.ui:createCheckbox(section, "Trinkets", "|cffFFFFFF Will use Trinkets")
-            br.ui:createDropdown(section, "Potion", {"Agility", "Bursting Blood"}, 1, "|cffFFFFFFPotion to use")
+            br.ui:createCheckbox(section, "Essences", "|cffFFFFFF Will use Essences")
+            br.ui:createDropdown(section, "Potion", {"Agility", "Unbridled Fury"}, 1, "|cffFFFFFFPotion to use")
             br.ui:createCheckbox(section, "Vanish", "|cffFFFFFF Will use Vanish")
             br.ui:createCheckbox(section, "Vendetta", "|cffFFFFFF Will use Vendetta")
             br.ui:createCheckbox(section, "Hold Vendetta", "|cffFFFFFF Will hold Vendetta for Vanish")
@@ -765,11 +766,11 @@ local function runRotation()
     local function actionList_Cooldowns()
         -- actions.cds=potion,if=buff.bloodlust.react|debuff.vendetta.up
         if useCDs() and ttd("target") > 15 and isChecked("Potion") and (hasBloodLust() or debuff.vendetta.exists("target")) and targetDistance < 5 then
-            if getOptionValue("Potion") == 1 and ttd("target") > 15 and use.able.battlePotionOfAgility() and not buff.battlePotionOfAgility.exists() then
-                use.battlePotionOfAgility()
+            if getOptionValue("Potion") == 1 and ttd("target") > 15 and use.able.superiorBattlePotionOfAgility() and not buff.superiorBattlePotionOfAgility.exists() then
+                use.superiorBattlePotionOfAgility()
                 return true
-            elseif getOptionValue("Potion") == 2 and ttd("target") > getOptionValue("CDs TTD Limit") and use.able.potionOfBurstingBlood() and not buff.potionOfBurstingBlood.exists() then
-                use.potionOfBurstingBlood()
+            elseif getOptionValue("Potion") == 2 and ttd("target") > getOptionValue("CDs TTD Limit") and use.able.potionOfUnbridledFury() and not buff.potionOfUnbridledFury.exists() then
+                use.potionOfUnbridledFury()
                 return true
             end
         end
@@ -849,7 +850,7 @@ local function runRotation()
                     if cast.vanish("player") then return true end
                 end
             end
-            if debuff.rupture.exists("target") then
+            if useCDs() and isChecked("Essences") and debuff.rupture.exists("target") then
                 --Worldvein Resonance
                 if cast.worldveinResonance("player") then return true end
                 --Memory of lucid Dreams
@@ -857,9 +858,13 @@ local function runRotation()
                     if cast.memoryOfLucidDreams("player") then return true end
                 end
                 --Guardian
-                if cast.guardianOfAzeroth("player") then return true end
+                if debuff.vendetta.exists("target") then
+                    if cast.guardianOfAzeroth("player") then return true end
+                end
                 --Blood Of The Enemy
-                if cast.bloodOfTheEnemy("player") then return true end
+                if debuff.vendetta.exists("target") then
+                    if cast.bloodOfTheEnemy("player") then return true end
+                end
                 --The Unbound Force
                 if cast.theUnboundForce("target") then return true end
             end
@@ -1088,7 +1093,7 @@ local function runRotation()
                 end
             end
             --tricks
-            if tricksUnit ~= nil and validTarget and targetDistance < 5 then
+            if tricksUnit ~= nil and validTarget and targetDistance < 5 and UnitThreatSituation("player") and UnitThreatSituation("player") >= 2 then
                 cast.tricksOfTheTrade(tricksUnit)
             end
             -- # Restealth if possible (no vulnerable enemies in combat)

--- a/System/Lists/Items.lua
+++ b/System/Lists/Items.lua
@@ -81,7 +81,7 @@ br.lists.items = {
     -- 8.2 Potions
     abyssalHealingPotion            = 169451,
     potionOfUnbridledFury           = 169299, -- DPS Potion
-    potionOfEmpoweredProximity      = 168592, -- DPS Potion (AoE)
+    potionOfEmpoweredProximity      = 168529, -- DPS Potion (AoE)
     potionOfFocusedResolve          = 168506, -- Crit Damage Potion
     potionOfWildMending             = 169300, -- Healer Potion
     superiorSteelskinPotion         = 168501, -- Armor Potion
@@ -101,11 +101,15 @@ br.lists.items = {
     dribblingInkpod                 = 169319,
     feloiledInfernalMachine         = 144482,
     galecallersBeak                 = 161379,
+    galecallersBoon                 = 159614,
+    grongsPrimalRage                = 165574,
     hornOfValor                     = 133642,
     jesHowler                       = 159627,
     pocketSizedComputationDevice    = 167555,
+    rampingAmplitudeGigavoltEngine  = 165580,
     specterOfBetrayal               = 151190,
     umbralMoonglaives               = 147012,
-    vigorTrinket                    = 165572,
     vialOfCeaselessToxins           = 147011,
+    vigorTrinket                    = 165572,
+    visionOfDemise                  = 169307,
 }

--- a/System/Lists/Spells.lua
+++ b/System/Lists/Spells.lua
@@ -8,7 +8,7 @@ local function flipRace()
             return "Human"
         elseif race == "Troll" then
             if class == 7 then
-                return "Draenei" 
+                return "Draenei"
             elseif class == 9 then
                 return "Human"
             else
@@ -56,7 +56,7 @@ local function flipRace()
             return "MagharOrc"
         elseif race == "Human" then
             if class == 2 then
-                return "BloodElf" 
+                return "BloodElf"
             else
                 return "Undead"
             end
@@ -104,9 +104,9 @@ local function flipRace()
     end
 end
 
-        
 
-        
+
+
 
 function getRacial()
     local forTheAlliance = UnitBuffID("player",193863) or false
@@ -352,11 +352,6 @@ br.lists.spells = {
             glyphs                          = {
 
             },
-            pets                            = {
-                activePet                   = activePet,
-                gargoyle                    = 27829,
-                risenSkulker                = 99541,
-            },
             talents                         = {
                 allWillServe                = 194916,
                 armyOfTheDead               = 276837,
@@ -380,7 +375,7 @@ br.lists.spells = {
                 unholyFrenzy                = 207289,
             },
             traits                          = {
-
+                magusOfTheDead              = 288417,
             },
         },
         -- All
@@ -485,6 +480,7 @@ br.lists.spells = {
             },
             traits                          = {
                 chaoticTransformation       = 288754,
+                eyesOfRage                  = 278500,
                 furiousGaze                 = 273231,
                 revolvingBlades             = 279581,
                 unboundChaos                = 275144,
@@ -798,6 +794,7 @@ br.lists.spells = {
                 tranquility                 = 740,
                 ursolsVortex                = 102793,
                 yserasGift                  = 145108,
+                swipeResto                  = 213764,
             },
             artifacts                       = {
 
@@ -845,6 +842,10 @@ br.lists.spells = {
                 springBlossoms              = 207385,
                 stonebark                   = 197061,
             },
+            traits                          = {
+                dawningSun                  = 276152,
+                highNoon                    = 278505,
+            }
         },
         -- All
         Shared = {
@@ -1191,9 +1192,6 @@ br.lists.spells = {
             },
             glyphs                          = {
 
-            },
-            pets                            = {
-                activePet                   = activePet,
             },
             talents                         = {
                 aMurderOfCrows              = 131894,
@@ -1676,6 +1674,8 @@ br.lists.spells = {
                 whirlingDragonPunch         = 152175,
             },
             traits                          = {
+                gloryOfTheDawn              = 288634,
+                openPalmStrikes             = 279918,
                 swiftRoundhouse             = 277669,
             }
         },
@@ -1749,6 +1749,7 @@ br.lists.spells = {
                 auraOfMercy                 = 183415,
                 auraMastery                 = 31821,
                 avengingWrath               = 31884,
+                avengingWrathCrit           = 294027,
                 beaconOfLight               = 53563,
                 beaconOfFaith               = 156910,
                 blessingOfSacrifice         = 6940,
@@ -2160,6 +2161,7 @@ br.lists.spells = {
             buffs                           = {
                 dispersion                  = 47585,
                 harvestedThoughts           = 288343,
+                lingeringInsanity            = 199849,
                 powerWordShield             = 17,
                 powerInfusion               = 10060,
                 shadowyInsight              = 124430,
@@ -2190,7 +2192,7 @@ br.lists.spells = {
                 --dominantMind                = 205367,
                 fortressOfTheMind           = 193195,
                 legacyOfTheVoid             = 193225,
-                lingeringInsanty            = 199849,
+                lingeringInsanity            = 199849,
                 --mania                       = 193173,
                 --masochism                   = 193063,
                 mindBomb                    = 205369,
@@ -2238,7 +2240,7 @@ br.lists.spells = {
             buffs                           = {
                 classHallSpeed              = 224098,
                 powerWordFortitude          = 21562,
-                
+
             },
             debuffs                         = {
 
@@ -3118,20 +3120,6 @@ br.lists.spells = {
             glyphs                          = {
                 glyphOfTheFelImp            = 219424,
             },
-            pets                            = {
-                darkglare                   = 103673,
-                demonicTyrant               = 135002,
-                doomguard                   = 78158,
-                dreadstlaker                = 98035,
-                felguard                    = 17252,
-                felhunter                   = 417,
-                imp                         = 416,
-                infernal                    = 78217,
-                succubus                    = 1863,
-                voidwalker                  = 1860,
-                wildImp                     = 55659,
-                wrathguard                  = 58965,
-            },
             talents                         = {
                 burningRush                 = 111400,
                 darkPact                    = 108416,
@@ -3391,6 +3379,8 @@ br.lists.spells = {
                 battlePotionOfAgility           = 279152,
                 battlePotionOfIntellect         = 279151,
                 battlePotionOfStrength          = 279153,
+                superiorBattlePotionOfAgility   = 298146,
+                potionOfUnbridledFury           = 300714,
                 blessingOfSacrifice 	        = 6940,
                 greaterBlessingOfKings 	        = 203538,
                 greaterBlessingOfWisdom	        = 203539,


### PR DESCRIPTION
### Added new prepots from 8.2:
- Superior Battle Potion of Agility
- Potion of Unbridled Fury

Added checkbox for essence usage in cooldown menu. Added a bit logic for essences Blood of the Enemy and Guardian of Azeroth, use only when Vendetta debuff exists to maximize the damage.

### Best assassination players and their usage of cds are here:
- Lady Ashvale (Guardian of Azeroth), check casts for guardian and vendetta
https://www.warcraftlogs.com/reports/rMnmAhwbPHtLyGxj#fight=7&type=casts&source=21

- Za'qul (Blood of the Enemy), check casts for blood and vendetta
https://www.warcraftlogs.com/reports/vBzy7rNGjRw1m9hA#fight=1&type=casts&source=9
