### PR TITLE
Logic for Razor Coral with Dribbing Ink

### DIFF
--- a/Rotations/Rogue/Assassination/AssassinationFiskee.lua
+++ b/Rotations/Rogue/Assassination/AssassinationFiskee.lua
@@ -819,7 +819,6 @@ local function runRotation()
                 useItem(14)
             end
         end
-        -- # Cyclonic Blast
 
         -- actions.cds+=/blood_fury,if=debuff.vendetta.up
         -- actions.cds+=/berserking,if=debuff.vendetta.up

--- a/Rotations/Rogue/Assassination/AssassinationFiskee.lua
+++ b/Rotations/Rogue/Assassination/AssassinationFiskee.lua
@@ -802,14 +802,24 @@ local function runRotation()
                 useItem(13)
             elseif hasEquiped(169311, 14) and (not debuff.razorCoral.exists("target") or debuff.vendetta.remain("target") > 10) then
                 useItem(14)
+        end
+        -- # Pop Razor Coral right before Dribbling Inkpod proc to increase it's chance to crit
+        if useCDs() and isCheced("Trinkets") then
+            if hasEquiped(169311, 13) and canUseItem(13) and hasEquiped(169319, 14) and ((UnitHealth("target")/UnitHealthMax("target"))*100) > 30 and ((UnitHealth("target")/UnitHealthMax("target"))*100) < 32 then
+                useItem(13)
+            elseif hasEquiped(169311, 14) and canUseItem(14) and hasEquiped(169319, 13) and ((UnitHealth("target")/UnitHealthMax("target"))*100) > 30 and ((UnitHealth("target")/UnitHealthMax("target"))*100) < 32 then
+                useItem(14)
             end
         end
         -- # Font of Azshara channel time 4 sec, 14 because Vendetta lasts 20 sec, combo >= to max elaborate planning talent
         if useCDs() and isChecked("Trinkets") and energy < 100 and combo >= 3 and cd.vendetta.remain() <= 14 then
-            if hasEquiped(169314) and canUseItem(169314) then
-                useItem(169314)
+            if hasEquiped(169314, 13) and canUseItem(13) then
+                useItem(13)
+            elseif hasEquiped(169314, 14) and canUseItem(14) then
+                useItem(14)
             end
         end
+        -- # Cyclonic Blast
 
         -- actions.cds+=/blood_fury,if=debuff.vendetta.up
         -- actions.cds+=/berserking,if=debuff.vendetta.up


### PR DESCRIPTION
### Explanation:
Ink does a big hit at 30%, it`s huge if it crits. Using coral with many stacks makes the chance to crit higher.

### Logic:
Pops coral at (30%-32%) and lasts for 20 seconds. Should be enough time to get the boss to lower than 30%. 31% would be the best but I don't know if the delay on the rotation could make it pop too late.

### Fixes:
I rewrote my logics for trinkets so it matches the previous trinket logics from fiskee