### PR TITLE
Don't break stealth for pre pull regrowth

### DIFF
--- a/Rotations/Druid/Feral/FeralCuteOne.lua
+++ b/Rotations/Druid/Feral/FeralCuteOne.lua
@@ -1266,7 +1266,7 @@ actionList.PreCombat = function()
             -- Regrowth
             -- regrowth,if=talent.bloodtalons.enabled
             if cast.able.regrowth("player") and talent.bloodtalons and not buff.bloodtalons.exists()
-                and (htTimer == nil or htTimer < GetTime() - 1)
+                and (htTimer == nil or htTimer < GetTime() - 1) and not buff.prowl.exists()
             then
                 if GetShapeshiftForm() ~= 0 then
                     -- CancelShapeshiftForm()


### PR DESCRIPTION
Won't break stealth anymore to proc bloodtalons which was bad for small pull timers (less than 6 seconds) as it causes you to open the fight without prowl buff.