### PR TITLE
S0ul3r assa fixes

### DIFF
--- a/Rotations/Rogue/Assassination/AssassinationFiskee.lua
+++ b/Rotations/Rogue/Assassination/AssassinationFiskee.lua
@@ -535,10 +535,10 @@ local function runRotation()
             if not moving and getOptionValue("Poison") == 2 and buff.woundPoison.remain() < 300 and not cast.last.woundPoison(1) then
                 if cast.woundPoison("player") then return true end
             end
-            -- if not moving and buff.cripplingPoison.remain() < 300 and not cast.last.cripplingPoison(1) then
-            --     if cast.cripplingPoison("player") then return true end
-            -- end
-            -- actions.precombat+=/stealth
+            if not moving and buff.cripplingPoison.remain() < 300 and not cast.last.cripplingPoison(1) then
+                if cast.cripplingPoison("player") then return true end
+            end
+            actions.precombat+=/stealth
             if isChecked("Auto Stealth") and IsUsableSpell(GetSpellInfo(spell.stealth)) and not cast.last.vanish() and not IsResting() and
             (botSpell ~= spell.stealth or (botSpellTime == nil or GetTime() - botSpellTime > 0.1)) then
                 if getOptionValue("Auto Stealth") == 1 then

--- a/Rotations/Rogue/Assassination/AssassinationFiskee.lua
+++ b/Rotations/Rogue/Assassination/AssassinationFiskee.lua
@@ -538,7 +538,7 @@ local function runRotation()
             if not moving and buff.cripplingPoison.remain() < 300 and not cast.last.cripplingPoison(1) then
                 if cast.cripplingPoison("player") then return true end
             end
-            actions.precombat+=/stealth
+            -- actions.precombat+=/stealth
             if isChecked("Auto Stealth") and IsUsableSpell(GetSpellInfo(spell.stealth)) and not cast.last.vanish() and not IsResting() and
             (botSpell ~= spell.stealth or (botSpellTime == nil or GetTime() - botSpellTime > 0.1)) then
                 if getOptionValue("Auto Stealth") == 1 then

--- a/Rotations/Rogue/Outlaw/OutlawImmy.lua
+++ b/Rotations/Rogue/Outlaw/OutlawImmy.lua
@@ -1349,6 +1349,11 @@ local function runRotation()
             if cast.bladeFlurry("player") then return true end
         end
 
+        --tricks
+        if tricksUnit ~= nil and validTarget and targetDistance < 5 and UnitThreatSituation("player") and UnitThreatSituation("player") >= 2 then
+            cast.tricksOfTheTrade(tricksUnit)
+        end
+
 
             if not IsCurrentSpell(6603) and inCombat and not stealth and isValidUnit("target") and getDistance("target") <= 5 and getFacing("player", "target") then
                 StartAttack("target")


### PR DESCRIPTION
### Assassination:

- Hold Vendetta to combo it with Toxic Blade - max out DPS in Vendetta frame (line 849)
- Cast Toxic Blade when Master Assassin buff is over - on pull we prefer to use Mutilate in MA
- Cast Vanish when Toxic Blade is active - to avoid wasting MA crit for TB (line 856)
- Vanish essence checks with MA - Mainly for boss fights, we don't want to waste MA frame for GoA cast (line 882)

### Outlaw

- Added missing cast for Tricks of Trade using trickUnit (old push)