### PR TITLE
Full corruption cloak support, more tweaks for assassination raiding

### DIFF
--- a/System/Lists/Spells.lua
+++ b/System/Lists/Spells.lua
@@ -3469,7 +3469,8 @@ br.lists.spells = {
                 recklessForce                   = 302932,
                 recklessForceCounter            = 298452,
                 seethingRage                    = 297126,
-				reapingFlames					= 311202,
+                reapingFlames					= 311202,
+                worldveinResonance              = 313310,
             },
             debuffs                             = {
                 bloodOfTheEnemy                 = 297108,
@@ -3486,7 +3487,6 @@ br.lists.spells = {
                 graspingTendrils                = 315176,
                 creepingMadness                 = 313255,
                 fixate				            = 318078,	
-
             },
             essences                            = {
                 aegisOfTheDeep                  = 298168,


### PR DESCRIPTION
Added Worldvein buff to Spells.lua, need it for assa rota
Added Vanish, Cloak of shadows, Shadowmeld and blind for dealing with corruption.
Keep in mind that using Vanish/Shadowmeld is a huge DPS loss when it is used for something minor like avoiding Thing from beyond.
Added tweaks for raiding with Worldvein, it is being cast before Vendetta, so we don't lose time during its buff.