### PR TITLE
Remove auto enabling of enabledx in the Tracker due to EWT saving this value.

### DIFF
--- a/System/UI/Windows/Config.lua
+++ b/System/UI/Windows/Config.lua
@@ -117,7 +117,7 @@ function br.ui:createConfigWindow()
     local function callTrackerEngine()
         -- Main
         section = br.ui:createSection(br.ui.window.config, "Main Settings")
-        br.ui:createDropdown(section,"Enable Tracker", {"Default","Alternate"}, 1, "Use alternate drawing mode in DX11 if you experience issues with Default.  If nothing shows up, type .enabledx")
+        br.ui:createDropdown(section,"Enable Tracker", {"Default","Alternate"}, 1, "Use alternate drawing mode in DX11 if you experience issues with Default. You must type .enabledx at least once to enable EWT's DX Drawing. This is automatically saved by EWT.")
         br.ui:createCheckbox(section,"Draw Lines to Tracked Objects")
         br.ui:createCheckbox(section,"Auto Interact with Any Tracked Object")
         br.ui:createCheckbox(section, "Rare Tracker", "Track All Rares In Range")
@@ -143,7 +143,7 @@ function br.ui:createConfigWindow()
                 local i = 0      -- iterator variable
                 local iter = function ()   -- iterator function
                 i = i + 1
-                if a[i] == nil then 
+                if a[i] == nil then
                     return nil
                 else return a[i], t[a[i]]
                 end

--- a/System/engines/Tracker.lua
+++ b/System/engines/Tracker.lua
@@ -1,7 +1,7 @@
 local trackerFrame = CreateFrame("Frame")
 local drawInterval = 0.006
 DrawTargets = {}
-local magicScale = 5/768
+local magicScale = 5/256
 trackerFrame:SetScript("OnUpdate", function(...)
 	if getOptionValue("Enable Tracker") == 2 and br.data.settings[br.selectedSpec].toggles["Power"] ~= nil and br.data.settings[br.selectedSpec].toggles["Power"] ~= 0 then
 		if not GetWoWWindow then return end -- a
@@ -28,7 +28,7 @@ trackerFrame:SetScript("OnUpdate", function(...)
 							Draw2DLine(p2dX * sWidth, p2dY * sHeight, o2dX * sWidth, o2dY * sHeight, 4)
 						end
 					end
-					Draw2DText(o2dX * sWidth - (sWidth * magicScale), o2dY * sHeight - (sHeight * magicScale), text)
+					Draw2DText(o2dX * sWidth - (sWidth * magicScale), o2dY * sHeight - (sHeight * (magicScale * 1/2)), text, 24)
 				end
 			end
 		end
@@ -43,7 +43,7 @@ local function trackObject(object,name,objectid,interact)
 	local playerDistance = GetDistanceBetweenPositions(pX,pY,pZ,xOb,yOb,zOb)
 	local cameraDistance = GetDistanceBetweenPositions(cX, cY, cZ, xOb, yOb, zOb)
 	if playerDistance <= cameraDistance then
-		if xOb ~= nil and GetDistanceBetweenPositions(pX,pY,pZ,xOb,yOb,zOb) < 500 then
+		if xOb ~= nil and GetDistanceBetweenPositions(pX,pY,pZ,xOb,yOb,zOb) < 200 then
 			--LibDraw.Circle(xOb,yOb,zOb, 2)
 			if name == "" or name == "Unknown" then name = ObjectName(object) end
 			if getOptionValue("Enable Tracker") == 2 then

--- a/System/engines/Tracker.lua
+++ b/System/engines/Tracker.lua
@@ -43,7 +43,7 @@ local function trackObject(object,name,objectid,interact)
 	local playerDistance = GetDistanceBetweenPositions(pX,pY,pZ,xOb,yOb,zOb)
 	local cameraDistance = GetDistanceBetweenPositions(cX, cY, cZ, xOb, yOb, zOb)
 	if playerDistance <= cameraDistance then
-		if xOb ~= nil and GetDistanceBetweenPositions(pX,pY,pZ,xOb,yOb,zOb) < 200 then
+		if xOb ~= nil and GetDistanceBetweenPositions(pX,pY,pZ,xOb,yOb,zOb) < 500 then
 			--LibDraw.Circle(xOb,yOb,zOb, 2)
 			if name == "" or name == "Unknown" then name = ObjectName(object) end
 			if getOptionValue("Enable Tracker") == 2 then
@@ -105,18 +105,12 @@ local function storeChestNotInList(object)
 	end
 end
 
-EnabledDx = false
 function br.objectTracker()
 	-- Track Objects
 	DrawTargets = {}
 	if (br.timer:useTimer("Tracker Lag", 0.07) or (isChecked("Quest Tracker") and br.timer:useTimer("Quest Lag", 0.5))) then
 		LibDraw.clearCanvas()
 		if isChecked("Enable Tracker") then
-			if not EnabledDx and EasyWowToolbox then
-				-- this cmd a secret not usable with ishackenabled or sethackenabled
-				RunMacroText(".enabledx")
-				EnabledDx = true
-			end
 			-- Horrific Vision - Objects Managed from OM from br.lists.horrificVisions and placed in br.objects when detected
 			local instanceID = IsInInstance() and select(8,GetInstanceInfo()) or 0
 			-- Reset Horrific Vision Potion Blacklist out of instance


### PR DESCRIPTION
Turns out EWT saves this value locally. By running enabledx again, it will infact disabledx rather than enable. Because of this, it's best to just let the user know they need to run ".enabledx" themselves at least once, rather than try and enable this ourselves. I can speak with reliasn regarding adding this to the `IsCheatEnabled` `SetCheatEnabled` functions given by the EWT api, but for now this change is the better option.