### PR TITLE
RestoAura - NS doesn't need unit

### DIFF
--- a/Rotations/Druid/Restoration/RestoAura.lua
+++ b/Rotations/Druid/Restoration/RestoAura.lua
@@ -1917,7 +1917,7 @@ local function runRotation()
 		end
 		-- Nature's Swiftness
 		if br.isChecked("Nature's Swiftness") and lowest.hp < br.getOptionValue("Nature's Swiftness") then
-			if cast.naturesSwiftness(lowest.unit) then
+			if cast.naturesSwiftness() then
 				br.addonDebug("Casting Nature's Swiftness")
 				return true
 			end


### PR DESCRIPTION
Rotation hangs on Nature's Swiftness invalid target. NS must be cast on "player" only. 