### PR TITLE
Feral covenant vs talent Convoke

### DIFF
--- a/Rotations/Druid/Feral/FeralCuteOne.lua
+++ b/Rotations/Druid/Feral/FeralCuteOne.lua
@@ -787,10 +787,14 @@ actionList.Cooldowns = function()
         end
         -- Convoke the Spirits
         -- convoke_the_spirits,if=buff.tigers_fury.up&combo_points<3|fight_remains<5
-        if ui.alwaysCdNever("Covenant Ability") and cast.able.convokeTheSpirits()
+        if ui.alwaysCdNever("Covenant Ability") and ((not talent.convokeTheSpiritsFeral and cast.able.convokeTheSpirits()) or (talent.convokeTheSpiritsFeral and cast.able.convokeTheSpiritsFeral())) 
             and ((buff.tigersFury.exists() and comboPoints < 3) or (unit.ttdGroup(5) < 5 and ui.useCDs() and not unit.isDummy(units.dyn5)))
         then
-            if cast.convokeTheSpirits() then ui.debug("Casting Convoke the Spirits [Night Fae]") return true end
+            if talent.convokeTheSpiritsFeral then
+                if cast.convokeTheSpiritsFeral() then ui.debug("Casting Convoke the Spirits [Talent]") return true end
+            else
+                if cast.convokeTheSpirits() then ui.debug("Casting Convoke the Spirits [Night Fae]") return true end
+            end
         end
         -- Racial: Berserking (Troll)
         -- berserking

--- a/System/Lists/Spells.lua
+++ b/System/Lists/Spells.lua
@@ -837,6 +837,7 @@ br.lists.spells = {
                 brutalSlash                 = 202028,
                 carnivorousInstinct         = 390902,
                 catsCuriosity               = 386318,
+                convokeTheSpiritsFeral      = 391528,
                 doubleClawedRake            = 391700,
                 dreadfulBleeding            = 391045,
                 feralFrenzy                 = 274837,


### PR DESCRIPTION
Night Fae Covenant Convoke and Feral Talent Convoke overlap or is replaced with latter one. Different spell IDs and cooldowns. In some cases rotation tries to cast wrong one and hangs. No point taking this talent with Night Fae. Mostly pre-patch issue.